### PR TITLE
ftr: add oracle-db app stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,11 @@ web/handlers/*.zip
 #-------------------------------------------------------------------------------
 # Database schema (excluded from global *.sql ignore)
 !bad-apples/database/init.sql
+
+# ReliPeople Oracle DB demo init scripts
+!oracle-db/oracle/init/01-schema.sql
+!oracle-db/oracle/init/02-seed.sql
+
+# NR Java agent config — copy from .example and edit locally (gitignored to prevent committing entity-linking changes)
+oracle-db/backend/newrelic.yml
+oracle-db/frontend/newrelic.yml

--- a/oracle-db/.env.example
+++ b/oracle-db/.env.example
@@ -1,0 +1,56 @@
+# -----------------------------------------------------------------------------
+# ReliPeople - Enterprise HR Self-Service Portal
+# Copy to .env and adjust as needed. All variables below have sensible defaults,
+# so the stack will come up with `docker compose up -d` even without a .env
+# file. Provide a NEW_RELIC_LICENSE_KEY to enable telemetry.
+# -----------------------------------------------------------------------------
+
+# -----------------------------------------------------------------------------
+# PORT CONFIGURATION
+# -----------------------------------------------------------------------------
+# Host ports mapped to container services. Change these if the defaults
+# collide with something else running on your machine.
+FRONTEND_PORT=8090
+BACKEND_PORT=8080
+ORACLE_PORT=1521
+
+# -----------------------------------------------------------------------------
+# ORACLE DATABASE CONFIGURATION
+# -----------------------------------------------------------------------------
+# The gvenzl/oracle-xe image creates APP_USER (ORACLE_APP_USER) inside the
+# XEPDB1 pluggable database with CONNECT + RESOURCE grants. The defaults
+# below work out of the box - no external provisioning step required.
+ORACLE_PASSWORD=ReliPeople1
+ORACLE_APP_USER=relipeople
+ORACLE_APP_PASSWORD=ReliPeople1
+ORACLE_SERVICE=FREEPDB1
+
+# -----------------------------------------------------------------------------
+# NEW RELIC CONFIGURATION
+# -----------------------------------------------------------------------------
+# Paste your ingest license key here to enable APM + logs-in-context.
+NEW_RELIC_LICENSE_KEY=your_license_key_here
+NEW_RELIC_APP_NAME_FRONTEND=relipeople_frontend
+NEW_RELIC_APP_NAME_BACKEND=relipeople_backend
+
+# -----------------------------------------------------------------------------
+# NRDOT COLLECTOR CONFIGURATION
+# -----------------------------------------------------------------------------
+# NR_OTLP_ENDPOINT   - New Relic OTLP ingest. EU accounts: https://otlp.eu01.nr-data.net
+# NRDOT_SERVICE_NAME - Entity name for the collector in New Relic APM
+# ORACLE_NRDOT_PASSWORD - Password for the c##nrdot monitoring user created by init SQL.
+#                         If you change this, you must also update 03-monitoring-user.sql
+#                         and re-seed the volume (docker compose down -v && up -d --build).
+# INTERNAL_TELEMETRY_METRICS_LEVEL - Collector self-monitoring verbosity: normal | detailed | basic | none
+NR_OTLP_ENDPOINT=otlp.nr-data.net:443   # EU: otlp.eu01.nr-data.net:443
+NRDOT_SERVICE_NAME=relipeople-nrdot
+ORACLE_NRDOT_PASSWORD=NrdotMonitor1
+INTERNAL_TELEMETRY_METRICS_LEVEL=normal
+
+# -----------------------------------------------------------------------------
+# LOAD GENERATOR TUNING
+# -----------------------------------------------------------------------------
+# LOADGEN_USERS    - concurrent simulated users
+# LOADGEN_INTERVAL - seconds between requests per simulated user
+LOADGEN_USERS=2
+LOADGEN_INTERVAL=8

--- a/oracle-db/README.md
+++ b/oracle-db/README.md
@@ -1,0 +1,251 @@
+# ReliPeople: Oracle DB Monitoring Demo
+
+A self-contained enterprise HR self-service portal designed to showcase **New Relic Oracle Database monitoring**. The app runs a realistic Java stack — Tomcat/JSP frontend, Spring Boot REST backend, Oracle Free 23c database — and seeds over 500,000 rows across seven tables so that the included slow queries produce interesting execution plans and wait events from the moment you start it.
+
+New Relic instrumentation includes:
+- **NR Java agent** on the frontend and backend — APM traces, logs-in-context, distributed tracing
+- **NRDOT collector** (`nrdot-collector-host`) scraping Oracle DB metrics directly via the Oracle DB receiver
+
+---
+
+## Architecture
+
+```mermaid
+flowchart LR
+    LG["🤖 Selenium Loadgen Python / headless Chrome browse 50% · reports 30% · leaves 20%"]
+
+    subgraph docker["Docker Compose — relipeople-network"]
+        FE["🌐 Frontend Tomcat 10.1 · JSP:8090 → :8080"]
+        BE["⚙️ Backend Spring Boot 3.2 REST API · :8080"]
+        DB[("🗄️ Oracle Free 23c gvenzl/oracle-free:1521 · FREEPDB1")]
+        OT["📡 NRDOT Collector nrdot-collector-host Oracle DB receiver"]
+    end
+
+    NR["☁️ New Relic"]
+
+    LG -->|HTTP| FE
+    FE -->|HTTP JSON| BE
+    BE -->|JDBC / ojdbc11| DB
+    FE & BE -->|NR Java agent| NR
+    OT -->|Oracle receiver| DB
+    OT -->|OTLP gRPC| NR
+```
+
+| Service | Image / Base | Role |
+|---|---|---|
+| `oracle` | `gvenzl/oracle-free:latest` | Oracle Free 23c, schema `relipeople` in FREEPDB1 |
+| `backend` | `eclipse-temurin:17-jre` | Spring Boot REST API, JdbcTemplate + HikariCP |
+| `frontend` | `tomcat:10.1-jdk17` | WAR deployed as ROOT, JSPs compiled by Jasper |
+| `loadgen` | `python:3.11-slim` | Selenium + headless Chromium, continuous load |
+| `otel-collector` | `debian:bookworm-slim` + NRDOT | Oracle DB receiver → New Relic OTLP |
+
+---
+
+## Slow Queries
+
+All tables are seeded with 500k+ total rows and **no indexes on foreign-key columns** — every join is a full table scan. This is intentional: it surfaces wait events and execution plans representative of under-tuned enterprise Oracle workloads.
+
+| Endpoint | Query shape | Why it's slow |
+|---|---|---|
+| `GET /employees?search=` | `LIKE '%term%'` + 4-table JOIN | Wildcard prefix prevents index use; 50k employee rows |
+| `GET /reports/payroll` | CTE + `LAG` / `AVG OVER PARTITION BY` | Window sort over 200k salary history rows + 4-table JOIN |
+| `GET /reports/departments` | `GROUP BY ROLLUP` + correlated subquery | Correlated `MAX(effective_date)` runs per-employee |
+| `GET /reports/performance` | 3-dimension `GROUP BY ROLLUP` | 150k review rows × 3-table JOIN; rollup on year + dept + role |
+| `GET /reports/leave-backlog` | Correlated subquery × 50 departments | Each department fires a full scan of 100k leave rows |
+| `GET /reports/salary-progression` | Full hash join 50k × 200k rows | Oracle must aggregate all salary rows before sorting top-500 |
+| `GET /leaves` | Multi-table JOIN + `TRUNC(end_date - start_date)` | Function on column prevents index seek; 100k leave rows |
+
+---
+
+## Directory Structure
+
+```
+oracle-db/
+├── .env.example                      # Copy to .env before first run
+├── docker-compose.yml
+│
+├── oracle/
+│   └── init/
+│       ├── 01-schema.sh              # DDL — 7 tables, no FK indexes (intentional)
+│       ├── 02-seed.sh                # 500k+ rows via CONNECT BY LEVEL
+│       └── 03-monitoring-user.sql    # c##nrdot CDB user + grants for NRDOT receiver
+│
+├── otel/
+│   ├── Dockerfile                    # Debian + nrdot-collector-host .deb (ARM64)
+│   ├── config.yaml                   # Oracle DB receiver + OTLP export pipeline
+│   └── internal-telemetry.yaml       # Collector self-monitoring → New Relic
+│
+├── backend/                          # Spring Boot 3.2 JAR
+│   ├── Dockerfile
+│   ├── newrelic.yml                  # NR Java agent config
+│   ├── pom.xml
+│   └── src/main/
+│       ├── java/com/newrelic/demo/relipeople/
+│       │   └── controller/
+│       │       ├── DashboardController.java
+│       │       ├── EmployeeController.java
+│       │       ├── ReportController.java
+│       │       └── LeaveController.java
+│       └── resources/
+│           └── application.properties
+│
+├── frontend/                         # Tomcat 10.1 WAR (Jasper compiles JSPs)
+│   ├── Dockerfile
+│   ├── newrelic.yml                  # NR Java agent config
+│   ├── pom.xml
+│   └── src/main/
+│       ├── java/com/newrelic/demo/relipeople/frontend/servlet/
+│       └── webapp/jsp/               # dashboard, employees, profile, reports, leaves
+│
+└── loadgen/                          # Selenium load generator
+    ├── Dockerfile
+    ├── load_gen.py                   # Thread orchestration
+    ├── journeys.py                   # Per-journey Selenium logic
+    └── requirements.txt
+```
+
+---
+
+## Prerequisites
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) (or Docker Engine + Compose v2)
+- At least **4 GB of RAM** allocated to Docker — Oracle Free requires ~2 GB on its own
+- Ports `1521`, `8080`, and `8090` free on your host (configurable in `.env`)
+- A **New Relic license key** (ingest key) — the stack will run without one, but telemetry won't reach New Relic
+
+No JDK, Maven, Python, or Oracle client installation is required; everything runs inside containers.
+
+---
+
+## Quick Start
+
+**1. Clone and enter the directory**
+
+```bash
+git clone https://github.com/newrelic/demo-apps.git
+cd demo-apps/oracle-db
+```
+
+**2. Configure environment**
+
+```bash
+cp .env.example .env
+cp backend/newrelic.yml.example backend/newrelic.yml
+cp frontend/newrelic.yml.example frontend/newrelic.yml
+```
+
+Open `.env` and set `NEW_RELIC_LICENSE_KEY` to your New Relic ingest license key. All other defaults work out of the box.
+
+> **EU accounts:** also set `NR_OTLP_ENDPOINT=otlp.eu01.nr-data.net:443` in `.env`.
+
+**3. Build and start**
+
+```bash
+docker compose up --build
+```
+
+The first run downloads base images, compiles both Maven projects, and installs the Oracle DB receiver. Expect **8–12 minutes** before all services are healthy.
+
+> **Oracle Free startup is the gating factor.** The database takes 3–5 minutes to initialize, run schema and seed scripts, and pass its healthcheck. The backend waits for Oracle, the frontend waits for the backend, and the loadgen waits for the frontend.
+
+(Optional) Watch startup progress:
+
+```bash
+docker compose logs -f oracle          # wait for "DATABASE IS READY TO USE!"
+docker compose logs -f backend         # wait for "Started ReliPeopleApplication"
+docker compose logs -f frontend        # wait for Tomcat deployment log
+docker compose logs -f otel-collector  # wait for "Everything is ready"
+docker compose logs -f loadgen         # should see "Frontend is ready" then journey logs
+```
+
+**4. Open the portal**
+
+```
+http://localhost:8090
+```
+
+---
+
+## Pages & Slow Query Triggers
+
+| URL | What it does |
+|---|---|
+| `/` | Dashboard — fast summary queries |
+| `/employees` | Directory search — type a partial name to trigger the LIKE scan |
+| `/employees/{id}` | Employee profile + salary history |
+| `/reports/payroll` | **Slow** — CTE + window functions; expect 5–30 s |
+| `/reports/departments` | ROLLUP + correlated subquery |
+| `/reports/performance` | 3-dimension ROLLUP across 150k review rows |
+| `/reports/leave-backlog` | **Slow** — correlated subquery per department, full scans |
+| `/reports/salary-progression` | **Slow** — full 200k-row hash join before sort |
+| `/leaves` | Leave requests — filter by status |
+
+The Selenium loadgen drives all of these automatically, but you can also hit the backend API directly:
+
+```bash
+curl "http://localhost:8080/api/reports/payroll?limit=100"
+curl "http://localhost:8080/api/reports/leave-backlog"
+curl "http://localhost:8080/api/reports/salary-progression"
+curl "http://localhost:8080/api/employees?search=smith&size=20"
+```
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `FRONTEND_PORT` | `8090` | Host port for the Tomcat frontend |
+| `BACKEND_PORT` | `8080` | Host port for the Spring Boot backend |
+| `ORACLE_PORT` | `1521` | Host port for Oracle |
+| `ORACLE_PASSWORD` | `ReliPeople1` | SYS / SYSTEM password |
+| `ORACLE_APP_USER` | `relipeople` | Application schema owner |
+| `ORACLE_APP_PASSWORD` | `ReliPeople1` | Application schema password |
+| `NEW_RELIC_LICENSE_KEY` | _(empty)_ | New Relic ingest license key — **required for telemetry** |
+| `NEW_RELIC_APP_NAME_FRONTEND` | `relipeople_frontend` | APM entity name for the Tomcat service |
+| `NEW_RELIC_APP_NAME_BACKEND` | `relipeople_backend` | APM entity name for the Spring Boot service |
+| `NR_OTLP_ENDPOINT` | `otlp.nr-data.net:443` | NRDOT OTLP ingest; EU: `otlp.eu01.nr-data.net:443` |
+| `NRDOT_SERVICE_NAME` | `relipeople-nrdot` | Entity name for the NRDOT collector in New Relic |
+| `ORACLE_NRDOT_PASSWORD` | `NrdotMonitor1` | Password for the `c##nrdot` monitoring user |
+| `INTERNAL_TELEMETRY_METRICS_LEVEL` | `normal` | NRDOT self-monitoring verbosity: `normal` \| `detailed` \| `none` |
+| `LOADGEN_USERS` | `2` | Concurrent Selenium user threads |
+| `LOADGEN_INTERVAL` | `8` | Seconds between journeys per user (±2 s jitter) |
+
+---
+
+## Optional: Oracle DB Entity Linking
+
+> Highly encouraged — this step connects your APM service traces directly to the Oracle DB entity in New Relic, enabling the "Service → Database" relationship view.
+
+Once the stack has been running for ~5 minutes and the backend and frontend services appear in **New Relic APM**, enable SQL comment tagging so the Oracle DB receiver can link query data back to those services:
+
+**1. Uncomment the `transaction_tracer` block** in both `backend/newrelic.yml` and `frontend/newrelic.yml`:
+
+```yaml
+transaction_tracer:
+  sql_metadata_comments: "apm_service_entity_guid"
+```
+
+**2. Restart the Java services:**
+
+```bash
+docker compose restart backend frontend
+```
+
+The agent will now prepend `/*nr_service_guid=<entity-guid>*/` to every SQL statement. New Relic's Oracle DB receiver reads that comment from `V$SQL` and draws the relationship. Allow **5–10 minutes** for it to appear in the entity map.
+
+---
+
+## Cleanup
+
+Stop and remove containers:
+
+```bash
+docker compose down
+```
+
+Remove containers **and** the Oracle data volume (full reset, triggers re-seed on next start):
+
+```bash
+docker compose down -v
+```

--- a/oracle-db/backend/Dockerfile
+++ b/oracle-db/backend/Dockerfile
@@ -1,0 +1,51 @@
+# syntax=docker/dockerfile:1
+
+# Stage 1: Build
+FROM eclipse-temurin:17-jdk AS builder
+
+# Install Maven
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends maven && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy pom.xml first to leverage Docker layer caching for dependencies
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+
+# Copy source and build
+COPY src ./src
+RUN mvn clean package -DskipTests -B
+
+# Stage 2: Runtime
+FROM eclipse-temurin:17-jre
+
+# Install curl for healthchecks
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN groupadd --system --gid 1001 relipeople && \
+    useradd --system --uid 1001 --gid relipeople --create-home --home-dir /home/relipeople relipeople
+
+WORKDIR /app
+
+COPY --from=builder /build/target/relipeople-backend.jar /app/app.jar
+
+RUN curl -L -o /app/newrelic.jar \
+        https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic-agent.jar
+
+COPY newrelic.yml /app/newrelic.yml
+
+RUN chown -R relipeople:relipeople /app
+
+USER relipeople
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:8080/actuator/health || exit 1
+
+CMD ["java", "-Xms256m", "-Xmx512m", "-XX:+UseG1GC", "-javaagent:/app/newrelic.jar", "-jar", "/app/app.jar"]

--- a/oracle-db/backend/newrelic.yml.example
+++ b/oracle-db/backend/newrelic.yml.example
@@ -1,0 +1,57 @@
+# ─── New Relic Java agent configuration ─────────────────────────────────────
+# Environment variables set in docker-compose.yml always override settings here.
+# Key vars already set: NEW_RELIC_LICENSE_KEY, NEW_RELIC_APP_NAME.
+# This file controls the settings that have no direct env-var equivalent.
+
+common: &default_settings
+
+  # ── Distributed tracing ──────────────────────────────────────────────────
+  distributed_tracing:
+    enabled: true
+
+  # ── Logs in context ──────────────────────────────────────────────────────
+  application_logging:
+    enabled: true
+    forwarding:
+      enabled: true
+      max_samples_stored: 10000
+    metrics:
+      enabled: true
+    local_decorating:
+      enabled: true
+
+  allow_all_headers: true
+
+  attributes:
+    exclude:
+      - request.headers.cookie
+      - request.headers.authorization
+      - request.headers.proxyAuthorization
+      - 'request.headers.setCookie*'
+      - 'request.headers.x*'
+      - response.headers.cookie
+      - response.headers.authorization
+      - response.headers.proxyAuthorization
+      - 'response.headers.setCookie*'
+      - 'response.headers.x*'
+
+  # ── Oracle DB entity linking (optional, highly encouraged) ───────────────
+  # When enabled, the agent prepends this service's entity GUID as a comment
+  # on every SQL statement:  /*nr_service_guid=<guid>*/ SELECT ...
+  # New Relic's Oracle DB receiver reads that comment from V$SQL and draws a
+  # "Service → Database" relationship, linking APM traces to DB query data.
+  #
+  # To enable:
+  #   1. Let the stack run for ~5 min so this service appears in New Relic APM.
+  #   2. Uncomment the `transaction_tracer` block below.
+  #   3. Restart: docker compose restart backend frontend
+  #   4. Allow 5–10 min for the relationship to appear in the NR entity map.
+  #
+  # transaction_tracer:
+  #   sql_metadata_comments: "nr_service_guid"
+
+development:
+  <<: *default_settings
+
+production:
+  <<: *default_settings

--- a/oracle-db/backend/pom.xml
+++ b/oracle-db/backend/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.2</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.newrelic.demo</groupId>
+    <artifactId>relipeople-backend</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <name>relipeople-backend</name>
+    <description>ReliPeople HR self-service portal backend</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11</artifactId>
+            <version>21.11.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>relipeople-backend</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/oracle-db/backend/src/main/java/com/newrelic/demo/relipeople/ReliPeopleApplication.java
+++ b/oracle-db/backend/src/main/java/com/newrelic/demo/relipeople/ReliPeopleApplication.java
@@ -1,0 +1,12 @@
+package com.newrelic.demo.relipeople;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ReliPeopleApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ReliPeopleApplication.class, args);
+    }
+}

--- a/oracle-db/backend/src/main/java/com/newrelic/demo/relipeople/controller/DashboardController.java
+++ b/oracle-db/backend/src/main/java/com/newrelic/demo/relipeople/controller/DashboardController.java
@@ -1,0 +1,44 @@
+package com.newrelic.demo.relipeople.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/dashboard")
+@CrossOrigin
+public class DashboardController {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @GetMapping("/stats")
+    public ResponseEntity<Map<String, Object>> getStats() {
+        Map<String, Object> stats = new LinkedHashMap<>();
+
+        Integer totalEmployees = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM EMPLOYEES", Integer.class);
+        Integer totalDepts = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM DEPARTMENTS", Integer.class);
+        Integer recentHires = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM EMPLOYEES WHERE hire_date >= SYSDATE - 90",
+                Integer.class);
+        Integer pendingLeaves = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM LEAVE_REQUESTS WHERE status = 'PENDING'",
+                Integer.class);
+
+        stats.put("totalEmployees", totalEmployees);
+        stats.put("totalDepts", totalDepts);
+        stats.put("recentHires", recentHires);
+        stats.put("pendingLeaves", pendingLeaves);
+
+        return ResponseEntity.ok(stats);
+    }
+}

--- a/oracle-db/backend/src/main/java/com/newrelic/demo/relipeople/controller/EmployeeController.java
+++ b/oracle-db/backend/src/main/java/com/newrelic/demo/relipeople/controller/EmployeeController.java
@@ -1,0 +1,114 @@
+package com.newrelic.demo.relipeople.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/employees")
+@CrossOrigin
+public class EmployeeController {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private NamedParameterJdbcTemplate namedJdbc;
+
+    @GetMapping
+    public ResponseEntity<List<Map<String, Object>>> listEmployees(
+            @RequestParam(name = "search", required = false, defaultValue = "") String search,
+            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "size", required = false, defaultValue = "50") int size) {
+
+        // Double-quoted aliases preserve camelCase casing through Oracle JDBC
+        String sql = "SELECT e.emp_id AS \"empId\", "
+                + "       e.first_name || ' ' || e.last_name AS \"fullName\", "
+                + "       e.email AS \"email\", "
+                + "       d.dept_name AS \"deptName\", "
+                + "       jg.job_title AS \"jobTitle\", "
+                + "       e.hire_date AS \"hireDate\" "
+                + "FROM EMPLOYEES e "
+                + "JOIN DEPARTMENTS d ON e.dept_id = d.dept_id "
+                + "JOIN JOB_GRADES jg ON e.job_id = jg.job_id "
+                + "WHERE LOWER(e.last_name) LIKE '%' || LOWER(:search) || '%' "
+                + "ORDER BY e.last_name, e.first_name "
+                + "OFFSET :offset ROWS FETCH NEXT :size ROWS ONLY";
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("search", search == null ? "" : search)
+                .addValue("offset", (long) page * size)
+                .addValue("size", size);
+
+        List<Map<String, Object>> rows = namedJdbc.queryForList(sql, params);
+        return ResponseEntity.ok(rows);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Map<String, Object>> getEmployee(@PathVariable("id") long id) {
+        String employeeSql = "SELECT e.emp_id AS \"empId\", "
+                + "       e.first_name AS \"firstName\", "
+                + "       e.last_name AS \"lastName\", "
+                + "       e.first_name || ' ' || e.last_name AS \"fullName\", "
+                + "       e.email AS \"email\", "
+                + "       e.hire_date AS \"hireDate\", "
+                + "       d.dept_id AS \"deptId\", "
+                + "       d.dept_name AS \"deptName\", "
+                + "       jg.job_id AS \"jobId\", "
+                + "       jg.job_title AS \"jobTitle\" "
+                + "FROM EMPLOYEES e "
+                + "JOIN DEPARTMENTS d ON e.dept_id = d.dept_id "
+                + "JOIN JOB_GRADES jg ON e.job_id = jg.job_id "
+                + "WHERE e.emp_id = ?";
+
+        List<Map<String, Object>> employees = jdbcTemplate.queryForList(employeeSql, id);
+        if (employees.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        Map<String, Object> employee = employees.get(0);
+
+        String salarySql = "SELECT sh.salary AS \"salary\", sh.effective_date AS \"effectiveDate\" "
+                + "FROM SALARY_HISTORY sh "
+                + "WHERE sh.emp_id = ? "
+                + "ORDER BY sh.effective_date DESC "
+                + "FETCH FIRST 1 ROW ONLY";
+
+        List<Map<String, Object>> salaries = jdbcTemplate.queryForList(salarySql, id);
+
+        Map<String, Object> result = new LinkedHashMap<>(employee);
+        if (!salaries.isEmpty()) {
+            result.put("currentSalary", salaries.get(0).get("salary"));
+            result.put("salaryEffectiveDate", salaries.get(0).get("effectiveDate"));
+        } else {
+            result.put("currentSalary", null);
+            result.put("salaryEffectiveDate", null);
+        }
+
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/{id}/salary-history")
+    public ResponseEntity<List<Map<String, Object>>> getSalaryHistory(@PathVariable("id") long id) {
+        String sql = "SELECT sh.salary_id AS \"salaryId\", sh.emp_id AS \"empId\", "
+                + "       sh.salary AS \"salary\", sh.effective_date AS \"effectiveDate\" "
+                + "FROM SALARY_HISTORY sh "
+                + "WHERE sh.emp_id = ? "
+                + "ORDER BY sh.effective_date DESC";
+
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql, id);
+        return ResponseEntity.ok(rows);
+    }
+}

--- a/oracle-db/backend/src/main/java/com/newrelic/demo/relipeople/controller/LeaveController.java
+++ b/oracle-db/backend/src/main/java/com/newrelic/demo/relipeople/controller/LeaveController.java
@@ -1,0 +1,55 @@
+package com.newrelic.demo.relipeople.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/leaves")
+@CrossOrigin
+public class LeaveController {
+
+    @Autowired
+    private NamedParameterJdbcTemplate namedJdbc;
+
+    @GetMapping
+    public ResponseEntity<List<Map<String, Object>>> listLeaves(
+            @RequestParam(name = "status", required = false) String status,
+            @RequestParam(name = "dept", required = false) String dept,
+            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "size", required = false, defaultValue = "50") int size) {
+
+        String sql = "SELECT lr.request_id AS \"requestId\", "
+                + "       e.first_name || ' ' || e.last_name AS \"empName\", "
+                + "       d.dept_name AS \"deptName\", "
+                + "       lr.start_date AS \"startDate\", "
+                + "       lr.end_date AS \"endDate\", "
+                + "       lr.status AS \"status\", "
+                + "       TRUNC(lr.end_date) - TRUNC(lr.start_date) AS \"durationDays\" "
+                + "FROM LEAVE_REQUESTS lr "
+                + "JOIN EMPLOYEES e ON lr.emp_id = e.emp_id "
+                + "JOIN DEPARTMENTS d ON lr.dept_id = d.dept_id "
+                + "WHERE (:status IS NULL OR lr.status = :status) "
+                + "  AND (:dept IS NULL OR d.dept_name LIKE '%' || :dept || '%') "
+                + "ORDER BY lr.start_date DESC "
+                + "OFFSET :offset ROWS FETCH NEXT :size ROWS ONLY";
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("status", (status == null || status.isBlank()) ? null : status)
+                .addValue("dept", (dept == null || dept.isBlank()) ? null : dept)
+                .addValue("offset", (long) page * size)
+                .addValue("size", size);
+
+        List<Map<String, Object>> rows = namedJdbc.queryForList(sql, params);
+        return ResponseEntity.ok(rows);
+    }
+}

--- a/oracle-db/backend/src/main/java/com/newrelic/demo/relipeople/controller/ReportController.java
+++ b/oracle-db/backend/src/main/java/com/newrelic/demo/relipeople/controller/ReportController.java
@@ -1,0 +1,148 @@
+package com.newrelic.demo.relipeople.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/reports")
+@CrossOrigin
+public class ReportController {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @GetMapping("/payroll")
+    public ResponseEntity<List<Map<String, Object>>> payroll(
+            @RequestParam(name = "limit", required = false, defaultValue = "200") int limit) {
+
+        String sql = "WITH current_salaries AS ( "
+                + "  SELECT sh.emp_id, "
+                + "         sh.salary AS current_salary, "
+                + "         ROW_NUMBER() OVER (PARTITION BY sh.emp_id ORDER BY sh.effective_date DESC) AS rn "
+                + "  FROM SALARY_HISTORY sh "
+                + ") "
+                + "SELECT e.emp_id AS \"empId\", "
+                + "       e.first_name || ' ' || e.last_name AS \"fullName\", "
+                + "       d.dept_name AS \"deptName\", "
+                + "       jg.job_title AS \"jobTitle\", "
+                + "       cs.current_salary AS \"currentSalary\", "
+                + "       AVG(cs.current_salary) OVER (PARTITION BY e.dept_id) AS \"deptAvgSalary\", "
+                + "       COUNT(e.emp_id) OVER (PARTITION BY e.dept_id) AS \"deptHeadcount\", "
+                + "       LAG(sh2.salary) OVER (PARTITION BY e.emp_id ORDER BY sh2.effective_date) AS \"previousSalary\" "
+                + "FROM EMPLOYEES e "
+                + "JOIN DEPARTMENTS d ON e.dept_id = d.dept_id "
+                + "JOIN JOB_GRADES jg ON e.job_id = jg.job_id "
+                + "JOIN current_salaries cs ON e.emp_id = cs.emp_id AND cs.rn = 1 "
+                + "LEFT JOIN SALARY_HISTORY sh2 ON e.emp_id = sh2.emp_id "
+                + "ORDER BY d.dept_name, e.last_name "
+                + "FETCH FIRST ? ROWS ONLY";
+
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql, limit);
+        return ResponseEntity.ok(rows);
+    }
+
+    @GetMapping("/departments")
+    public ResponseEntity<List<Map<String, Object>>> departments() {
+        String sql = "SELECT NVL(d.dept_name, 'ALL DEPARTMENTS') AS \"deptName\", "
+                + "       NVL(l.city, 'All Cities') AS \"city\", "
+                + "       NVL(l.state, '-') AS \"state\", "
+                + "       COUNT(DISTINCT e.emp_id) AS \"headcount\", "
+                + "       ROUND(AVG(cs.current_salary), 2) AS \"avgCurrentSalary\", "
+                + "       SUM(cs.current_salary) AS \"totalPayroll\" "
+                + "FROM DEPARTMENTS d "
+                + "JOIN LOCATIONS l ON d.location_id = l.location_id "
+                + "LEFT JOIN EMPLOYEES e ON e.dept_id = d.dept_id "
+                + "LEFT JOIN ( "
+                + "    SELECT emp_id, salary AS current_salary "
+                + "    FROM SALARY_HISTORY sh1 "
+                + "    WHERE sh1.effective_date = ( "
+                + "        SELECT MAX(sh2.effective_date) FROM SALARY_HISTORY sh2 "
+                + "        WHERE sh2.emp_id = sh1.emp_id "
+                + "    ) "
+                + ") cs ON e.emp_id = cs.emp_id "
+                + "GROUP BY ROLLUP(d.dept_name, l.city, l.state) "
+                + "ORDER BY GROUPING(d.dept_name), d.dept_name NULLS LAST";
+
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql);
+        return ResponseEntity.ok(rows);
+    }
+
+    @GetMapping("/performance")
+    public ResponseEntity<List<Map<String, Object>>> performance() {
+        // Nulls pass through for rollup rows so JSP ${empty row.X} rollup detection works
+        String sql = "SELECT TO_CHAR(pr.review_year) AS \"reviewYear\", "
+                + "       d.dept_name AS \"deptName\", "
+                + "       jg.job_title AS \"jobTitle\", "
+                + "       COUNT(pr.review_id) AS \"reviewCount\", "
+                + "       ROUND(AVG(pr.score), 2) AS \"avgScore\", "
+                + "       MIN(pr.score) AS \"minScore\", "
+                + "       MAX(pr.score) AS \"maxScore\", "
+                + "       SUM(CASE WHEN pr.score >= 4 THEN 1 ELSE 0 END) AS \"highPerformers\" "
+                + "FROM PERFORMANCE_REVIEWS pr "
+                + "JOIN EMPLOYEES e ON pr.emp_id = e.emp_id "
+                + "JOIN DEPARTMENTS d ON e.dept_id = d.dept_id "
+                + "JOIN JOB_GRADES jg ON e.job_id = jg.job_id "
+                + "GROUP BY ROLLUP(pr.review_year, d.dept_name, jg.job_title) "
+                + "ORDER BY GROUPING(pr.review_year), pr.review_year DESC NULLS LAST, "
+                + "         GROUPING(d.dept_name), d.dept_name NULLS LAST";
+
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql);
+        return ResponseEntity.ok(rows);
+    }
+
+    @GetMapping("/leave-backlog")
+    public ResponseEntity<List<Map<String, Object>>> leaveBacklog() {
+        // Correlated subquery runs once per department — each fires a full scan of
+        // LEAVE_REQUESTS + EMPLOYEES on unindexed FK dept_id.
+        String sql = "SELECT d.dept_name AS \"deptName\", "
+                + "       COUNT(DISTINCT e.emp_id) AS \"totalEmployees\", "
+                + "       COUNT(lr.request_id) AS \"totalLeaves\", "
+                + "       SUM(CASE WHEN lr.status = 'PENDING' THEN 1 ELSE 0 END) AS \"pendingCount\", "
+                + "       ROUND(AVG(lr.end_date - lr.start_date), 1) AS \"avgLeaveDays\", "
+                + "       (SELECT COUNT(*) "
+                + "          FROM LEAVE_REQUESTS lr2 "
+                + "          JOIN EMPLOYEES e2 ON lr2.emp_id = e2.emp_id "
+                + "         WHERE e2.dept_id = d.dept_id "
+                + "           AND lr2.status = 'PENDING') AS \"confirmedPending\" "
+                + "FROM DEPARTMENTS d "
+                + "LEFT JOIN EMPLOYEES e ON e.dept_id = d.dept_id "
+                + "LEFT JOIN LEAVE_REQUESTS lr ON lr.emp_id = e.emp_id "
+                + "GROUP BY d.dept_id, d.dept_name "
+                + "ORDER BY COUNT(lr.request_id) DESC";
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql);
+        return ResponseEntity.ok(rows);
+    }
+
+    @GetMapping("/salary-progression")
+    public ResponseEntity<List<Map<String, Object>>> salaryProgression() {
+        // Full hash join of EMPLOYEES (50K) x SALARY_HISTORY (200K) on unindexed FK.
+        // Oracle must aggregate all 200K rows before applying FETCH FIRST order.
+        String sql = "SELECT e.first_name || ' ' || e.last_name AS \"employeeName\", "
+                + "       d.dept_name AS \"deptName\", "
+                + "       jg.job_title AS \"jobTitle\", "
+                + "       COUNT(sh.salary_id) AS \"salaryChanges\", "
+                + "       MIN(sh.salary) AS \"startingSalary\", "
+                + "       MAX(sh.salary) AS \"currentSalary\", "
+                + "       MAX(sh.salary) - MIN(sh.salary) AS \"totalGrowth\", "
+                + "       ROUND((MAX(sh.salary) - MIN(sh.salary)) "
+                + "             / NULLIF(MIN(sh.salary), 0) * 100, 1) AS \"growthPct\" "
+                + "FROM EMPLOYEES e "
+                + "JOIN SALARY_HISTORY sh ON sh.emp_id = e.emp_id "
+                + "JOIN DEPARTMENTS d ON e.dept_id = d.dept_id "
+                + "JOIN JOB_GRADES jg ON e.job_id = jg.job_id "
+                + "GROUP BY e.emp_id, e.first_name, e.last_name, d.dept_name, jg.job_title "
+                + "ORDER BY MAX(sh.salary) - MIN(sh.salary) DESC "
+                + "FETCH FIRST 500 ROWS ONLY";
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(sql);
+        return ResponseEntity.ok(rows);
+    }
+}

--- a/oracle-db/backend/src/main/resources/application.properties
+++ b/oracle-db/backend/src/main/resources/application.properties
@@ -1,0 +1,27 @@
+spring.application.name=relipeople-backend
+server.port=8080
+
+# Oracle datasource
+spring.datasource.url=jdbc:oracle:thin:@${ORACLE_HOST:oracle}:${ORACLE_PORT:1521}/${ORACLE_SERVICE:FREEPDB1}
+spring.datasource.username=${ORACLE_USER:relipeople}
+spring.datasource.password=${ORACLE_PASSWORD:relipeople}
+spring.datasource.driver-class-name=oracle.jdbc.OracleDriver
+
+# HikariCP
+spring.datasource.hikari.maximum-pool-size=10
+spring.datasource.hikari.minimum-idle=2
+spring.datasource.hikari.connection-test-query=SELECT 1 FROM DUAL
+spring.datasource.hikari.pool-name=RelipeoplePool
+spring.datasource.hikari.connection-timeout=30000
+spring.datasource.hikari.idle-timeout=600000
+spring.datasource.hikari.max-lifetime=1800000
+spring.datasource.hikari.initialization-fail-timeout=-1
+
+# Actuator
+management.endpoints.web.exposure.include=health,info
+management.endpoint.health.show-details=always
+
+# Logging
+logging.level.root=INFO
+logging.level.com.newrelic.demo.relipeople=INFO
+logging.level.org.springframework.jdbc.core=INFO

--- a/oracle-db/docker-compose.yml
+++ b/oracle-db/docker-compose.yml
@@ -1,0 +1,130 @@
+name: oracle-db
+
+services:
+  oracle:
+    image: gvenzl/oracle-free:latest
+    container_name: relipeople-oracle
+    environment:
+      ORACLE_PASSWORD: ${ORACLE_PASSWORD:-ReliPeople1}
+      APP_USER: ${ORACLE_APP_USER:-relipeople}
+      APP_USER_PASSWORD: ${ORACLE_APP_PASSWORD:-ReliPeople1}
+      ORACLE_NRDOT_PASSWORD: ${ORACLE_NRDOT_PASSWORD:-NrdotMonitor1}
+    ports:
+      - "${ORACLE_PORT:-1521}:1521"
+    volumes:
+      - oracle-data:/opt/oracle/oradata
+      - ./oracle/init:/container-entrypoint-initdb.d:ro
+      - ./oracle/healthcheck.sh:/usr/local/bin/oracle-healthcheck.sh:ro
+    healthcheck:
+      test: ["CMD-SHELL", "sh /usr/local/bin/oracle-healthcheck.sh"]
+      interval: 30s
+      timeout: 15s
+      retries: 30
+      start_period: 600s
+    networks:
+      - relipeople-network
+    restart: unless-stopped
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: relipeople-backend
+    environment:
+      - SERVER_PORT=8080
+      - ORACLE_HOST=oracle
+      - ORACLE_PORT=1521
+      - ORACLE_SERVICE=FREEPDB1
+      - ORACLE_USER=${ORACLE_APP_USER:-relipeople}
+      - ORACLE_PASSWORD=${ORACLE_APP_PASSWORD:-ReliPeople1}
+      - NEW_RELIC_LICENSE_KEY=${NEW_RELIC_LICENSE_KEY:-}
+      - NEW_RELIC_APP_NAME=${NEW_RELIC_APP_NAME_BACKEND:-relipeople_backend}
+    ports:
+      - "${BACKEND_PORT:-8080}:8080"
+    depends_on:
+      oracle:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/actuator/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    networks:
+      - relipeople-network
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    container_name: relipeople-frontend
+    environment:
+      - BACKEND_URL=http://backend:8080
+      - NEW_RELIC_LICENSE_KEY=${NEW_RELIC_LICENSE_KEY:-}
+      - NEW_RELIC_APP_NAME=${NEW_RELIC_APP_NAME_FRONTEND:-relipeople_frontend}
+    ports:
+      - "${FRONTEND_PORT:-8090}:8080"
+    depends_on:
+      backend:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8080/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
+    networks:
+      - relipeople-network
+
+  loadgen:
+    build:
+      context: ./loadgen
+      dockerfile: Dockerfile
+    container_name: relipeople-loadgen
+    environment:
+      - FRONTEND_URL=http://frontend:8080
+      - LOADGEN_USERS=${LOADGEN_USERS:-2}
+      - LOADGEN_INTERVAL=${LOADGEN_INTERVAL:-8}
+    depends_on:
+      frontend:
+        condition: service_healthy
+    networks:
+      - relipeople-network
+    restart: unless-stopped
+
+  otel-collector:
+    build:
+      context: ./otel
+      dockerfile: Dockerfile
+    container_name: relipeople-nrdot
+    environment:
+      - NEW_RELIC_LICENSE_KEY=${NEW_RELIC_LICENSE_KEY}
+      - NR_OTLP_ENDPOINT=${NR_OTLP_ENDPOINT:-otlp.nr-data.net:443}
+      - ORACLE_NRDOT_PASSWORD=${ORACLE_NRDOT_PASSWORD:-NrdotMonitor1}
+      - INTERNAL_TELEMETRY_NEW_RELIC_LICENSE_KEY=${NEW_RELIC_LICENSE_KEY}
+      - INTERNAL_TELEMETRY_SERVICE_NAME=${NRDOT_SERVICE_NAME:-relipeople-nrdot}
+      - INTERNAL_TELEMETRY_METRICS_LEVEL=${INTERNAL_TELEMETRY_METRICS_LEVEL:-normal}
+    volumes:
+      - ./otel/config.yaml:/etc/nrdot-collector-host/config.yaml:ro
+      - ./otel/internal-telemetry.yaml:/etc/nrdot-collector-host/internal-telemetry.yaml:ro
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:13133/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    depends_on:
+      oracle:
+        condition: service_healthy
+    networks:
+      - relipeople-network
+    restart: unless-stopped
+
+networks:
+  relipeople-network:
+    driver: bridge
+    name: relipeople-network
+
+volumes:
+  oracle-data:
+    name: relipeople-oracle-data

--- a/oracle-db/frontend/Dockerfile
+++ b/oracle-db/frontend/Dockerfile
@@ -1,0 +1,32 @@
+# Stage 1: Build WAR
+FROM eclipse-temurin:17-jdk AS builder
+
+WORKDIR /build
+
+RUN apt-get update && apt-get install -y maven && rm -rf /var/lib/apt/lists/*
+
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+
+COPY src ./src
+RUN mvn clean package -DskipTests -B
+
+# Stage 2: Runtime
+FROM tomcat:10.1-jdk17
+
+RUN rm -rf /usr/local/tomcat/webapps/*
+
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/relipeople.war /usr/local/tomcat/webapps/ROOT.war
+
+RUN curl -L -o /usr/local/tomcat/newrelic.jar \
+        https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic-agent.jar
+
+COPY newrelic.yml /usr/local/tomcat/newrelic.yml
+
+ENV CATALINA_OPTS="-javaagent:/usr/local/tomcat/newrelic.jar -Xms256m -Xmx512m -XX:+UseG1GC"
+
+EXPOSE 8080
+
+CMD ["catalina.sh", "run"]

--- a/oracle-db/frontend/newrelic.yml.example
+++ b/oracle-db/frontend/newrelic.yml.example
@@ -1,0 +1,57 @@
+# ─── New Relic Java agent configuration ─────────────────────────────────────
+# Environment variables set in docker-compose.yml always override settings here.
+# Key vars already set: NEW_RELIC_LICENSE_KEY, NEW_RELIC_APP_NAME.
+# This file controls the settings that have no direct env-var equivalent.
+
+common: &default_settings
+
+  # ── Distributed tracing ──────────────────────────────────────────────────
+  distributed_tracing:
+    enabled: true
+
+  # ── Logs in context ──────────────────────────────────────────────────────
+  application_logging:
+    enabled: true
+    forwarding:
+      enabled: true
+      max_samples_stored: 10000
+    metrics:
+      enabled: true
+    local_decorating:
+      enabled: true
+
+  allow_all_headers: true
+
+  attributes:
+    exclude:
+      - request.headers.cookie
+      - request.headers.authorization
+      - request.headers.proxyAuthorization
+      - 'request.headers.setCookie*'
+      - 'request.headers.x*'
+      - response.headers.cookie
+      - response.headers.authorization
+      - response.headers.proxyAuthorization
+      - 'response.headers.setCookie*'
+      - 'response.headers.x*'
+
+  # ── Oracle DB entity linking (optional, highly encouraged) ───────────────
+  # When enabled, the agent prepends this service's entity GUID as a comment
+  # on every SQL statement:  /*nr_service_guid=<guid>*/ SELECT ...
+  # New Relic's Oracle DB receiver reads that comment from V$SQL and draws a
+  # "Service → Database" relationship, linking APM traces to DB query data.
+  #
+  # To enable:
+  #   1. Let the stack run for ~5 min so this service appears in New Relic APM.
+  #   2. Uncomment the `transaction_tracer` block below.
+  #   3. Restart: docker compose restart backend frontend
+  #   4. Allow 5–10 min for the relationship to appear in the NR entity map.
+  #
+  # transaction_tracer:
+  #   sql_metadata_comments: "nr_service_guid"
+
+development:
+  <<: *default_settings
+
+production:
+  <<: *default_settings

--- a/oracle-db/frontend/pom.xml
+++ b/oracle-db/frontend/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.newrelic.demo</groupId>
+    <artifactId>relipeople-frontend</artifactId>
+    <version>1.0.0</version>
+    <packaging>war</packaging>
+    <name>relipeople-frontend</name>
+    <description>ReliPeople HR self-service portal frontend (Tomcat/JSP)</description>
+
+    <properties>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
+            <version>3.1.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet.jsp.jstl</groupId>
+            <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.3.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.16.1</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>relipeople</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.4.0</version>
+                <configuration>
+                    <failOnMissingWebXml>true</failOnMissingWebXml>
+                    <warName>relipeople</warName>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/oracle-db/frontend/src/main/java/com/newrelic/demo/relipeople/frontend/servlet/DashboardServlet.java
+++ b/oracle-db/frontend/src/main/java/com/newrelic/demo/relipeople/frontend/servlet/DashboardServlet.java
@@ -1,0 +1,48 @@
+package com.newrelic.demo.relipeople.frontend.servlet;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@WebServlet("")
+public class DashboardServlet extends HttpServlet {
+
+    private static final String BACKEND_URL = System.getenv().getOrDefault("BACKEND_URL", "http://backend:8080");
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        Map<String, Object> stats;
+        try {
+            stats = fetchMap("/api/dashboard/stats");
+        } catch (IOException e) {
+            stats = new HashMap<>();
+            request.setAttribute("error", "Unable to load dashboard stats: " + e.getMessage());
+        }
+        request.setAttribute("stats", stats);
+        request.getRequestDispatcher("/jsp/dashboard.jsp").forward(request, response);
+    }
+
+    private Map<String, Object> fetchMap(String endpoint) throws IOException {
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet get = new HttpGet(BACKEND_URL + endpoint);
+            return client.execute(get, resp -> {
+                String body = EntityUtils.toString(resp.getEntity());
+                return MAPPER.readValue(body, new TypeReference<Map<String, Object>>() {});
+            });
+        }
+    }
+}

--- a/oracle-db/frontend/src/main/java/com/newrelic/demo/relipeople/frontend/servlet/EmployeeServlet.java
+++ b/oracle-db/frontend/src/main/java/com/newrelic/demo/relipeople/frontend/servlet/EmployeeServlet.java
@@ -1,0 +1,107 @@
+package com.newrelic.demo.relipeople.frontend.servlet;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@WebServlet(urlPatterns = {"/employees", "/employees/*"})
+public class EmployeeServlet extends HttpServlet {
+
+    private static final String BACKEND_URL = System.getenv().getOrDefault("BACKEND_URL", "http://backend:8080");
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        String pathInfo = request.getPathInfo();
+
+        if (pathInfo != null && pathInfo.length() > 1) {
+            String empId = pathInfo.substring(1);
+            if (empId.endsWith("/")) {
+                empId = empId.substring(0, empId.length() - 1);
+            }
+            handleEmployeeProfile(request, response, empId);
+        } else {
+            handleEmployeeList(request, response);
+        }
+    }
+
+    private void handleEmployeeList(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        String search = request.getParameter("search");
+        String page = request.getParameter("page");
+        if (search == null) search = "";
+        if (page == null || page.isEmpty()) page = "0";
+
+        String endpoint = "/api/employees?search=" +
+                URLEncoder.encode(search, StandardCharsets.UTF_8) +
+                "&page=" + URLEncoder.encode(page, StandardCharsets.UTF_8) +
+                "&size=50";
+
+        List<Map<String, Object>> employees;
+        try {
+            employees = fetchList(endpoint);
+        } catch (IOException e) {
+            employees = Collections.emptyList();
+            request.setAttribute("error", "Unable to load employees: " + e.getMessage());
+        }
+
+        request.setAttribute("employees", employees);
+        request.setAttribute("search", search);
+        request.getRequestDispatcher("/jsp/employees.jsp").forward(request, response);
+    }
+
+    private void handleEmployeeProfile(HttpServletRequest request, HttpServletResponse response, String empId)
+            throws ServletException, IOException {
+        Map<String, Object> employee;
+        List<Map<String, Object>> salaryHistory;
+        try {
+            employee = fetchMap("/api/employees/" + URLEncoder.encode(empId, StandardCharsets.UTF_8));
+            salaryHistory = fetchList("/api/employees/" + URLEncoder.encode(empId, StandardCharsets.UTF_8) + "/salary-history");
+        } catch (IOException e) {
+            employee = new HashMap<>();
+            salaryHistory = Collections.emptyList();
+            request.setAttribute("error", "Unable to load employee: " + e.getMessage());
+        }
+
+        request.setAttribute("employee", employee);
+        request.setAttribute("salaryHistory", salaryHistory);
+        request.getRequestDispatcher("/jsp/employee-profile.jsp").forward(request, response);
+    }
+
+    private List<Map<String, Object>> fetchList(String endpoint) throws IOException {
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet get = new HttpGet(BACKEND_URL + endpoint);
+            return client.execute(get, resp -> {
+                String body = EntityUtils.toString(resp.getEntity());
+                return MAPPER.readValue(body, new TypeReference<List<Map<String, Object>>>() {});
+            });
+        }
+    }
+
+    private Map<String, Object> fetchMap(String endpoint) throws IOException {
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet get = new HttpGet(BACKEND_URL + endpoint);
+            return client.execute(get, resp -> {
+                String body = EntityUtils.toString(resp.getEntity());
+                return MAPPER.readValue(body, new TypeReference<Map<String, Object>>() {});
+            });
+        }
+    }
+}

--- a/oracle-db/frontend/src/main/java/com/newrelic/demo/relipeople/frontend/servlet/HealthServlet.java
+++ b/oracle-db/frontend/src/main/java/com/newrelic/demo/relipeople/frontend/servlet/HealthServlet.java
@@ -1,0 +1,19 @@
+package com.newrelic.demo.relipeople.frontend.servlet;
+
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@WebServlet("/health")
+public class HealthServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType("text/plain");
+        response.getWriter().write("OK");
+    }
+}

--- a/oracle-db/frontend/src/main/java/com/newrelic/demo/relipeople/frontend/servlet/LeaveServlet.java
+++ b/oracle-db/frontend/src/main/java/com/newrelic/demo/relipeople/frontend/servlet/LeaveServlet.java
@@ -1,0 +1,63 @@
+package com.newrelic.demo.relipeople.frontend.servlet;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@WebServlet("/leaves")
+public class LeaveServlet extends HttpServlet {
+
+    private static final String BACKEND_URL = System.getenv().getOrDefault("BACKEND_URL", "http://backend:8080");
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        String status = request.getParameter("status");
+        String page = request.getParameter("page");
+        if (status == null) status = "";
+        if (page == null || page.isEmpty()) page = "0";
+
+        String endpoint = "/api/leaves?status=" +
+                URLEncoder.encode(status, StandardCharsets.UTF_8) +
+                "&page=" + URLEncoder.encode(page, StandardCharsets.UTF_8) +
+                "&size=50";
+
+        List<Map<String, Object>> leaves;
+        try {
+            leaves = fetchList(endpoint);
+        } catch (IOException e) {
+            leaves = Collections.emptyList();
+            request.setAttribute("error", "Unable to load leave requests: " + e.getMessage());
+        }
+
+        request.setAttribute("leaves", leaves);
+        request.setAttribute("statusFilter", status);
+        request.getRequestDispatcher("/jsp/leaves.jsp").forward(request, response);
+    }
+
+    private List<Map<String, Object>> fetchList(String endpoint) throws IOException {
+        try (CloseableHttpClient client = HttpClients.createDefault()) {
+            HttpGet get = new HttpGet(BACKEND_URL + endpoint);
+            return client.execute(get, resp -> {
+                String body = EntityUtils.toString(resp.getEntity());
+                return MAPPER.readValue(body, new TypeReference<List<Map<String, Object>>>() {});
+            });
+        }
+    }
+}

--- a/oracle-db/frontend/src/main/java/com/newrelic/demo/relipeople/frontend/servlet/ReportServlet.java
+++ b/oracle-db/frontend/src/main/java/com/newrelic/demo/relipeople/frontend/servlet/ReportServlet.java
@@ -1,0 +1,98 @@
+package com.newrelic.demo.relipeople.frontend.servlet;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.util.Timeout;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@WebServlet(urlPatterns = {"/reports/payroll", "/reports/departments", "/reports/performance",
+        "/reports/leave-backlog", "/reports/salary-progression"})
+public class ReportServlet extends HttpServlet {
+
+    private static final String BACKEND_URL = System.getenv().getOrDefault("BACKEND_URL", "http://backend:8080");
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final RequestConfig LONG_TIMEOUT = RequestConfig.custom()
+            .setConnectTimeout(Timeout.ofSeconds(10))
+            .setResponseTimeout(Timeout.ofSeconds(120))
+            .setConnectionRequestTimeout(Timeout.ofSeconds(10))
+            .build();
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        String path = request.getServletPath();
+
+        String endpoint;
+        String attrName;
+        String jspPath;
+
+        switch (path) {
+            case "/reports/payroll":
+                endpoint = "/api/reports/payroll?limit=200";
+                attrName = "payrollData";
+                jspPath = "/jsp/payroll-report.jsp";
+                break;
+            case "/reports/departments":
+                endpoint = "/api/reports/departments";
+                attrName = "deptData";
+                jspPath = "/jsp/dept-analytics.jsp";
+                break;
+            case "/reports/performance":
+                endpoint = "/api/reports/performance";
+                attrName = "performanceData";
+                jspPath = "/jsp/performance-report.jsp";
+                break;
+            case "/reports/leave-backlog":
+                endpoint = "/api/reports/leave-backlog";
+                attrName = "leaveBacklogData";
+                jspPath = "/jsp/leave-backlog-report.jsp";
+                break;
+            case "/reports/salary-progression":
+                endpoint = "/api/reports/salary-progression";
+                attrName = "salaryProgressionData";
+                jspPath = "/jsp/salary-progression-report.jsp";
+                break;
+            default:
+                response.sendError(HttpServletResponse.SC_NOT_FOUND);
+                return;
+        }
+
+        List<Map<String, Object>> data;
+        try {
+            data = fetchList(endpoint);
+        } catch (IOException e) {
+            data = Collections.emptyList();
+            request.setAttribute("error", "Unable to load report: " + e.getMessage());
+        }
+
+        request.setAttribute(attrName, data);
+        request.getRequestDispatcher(jspPath).forward(request, response);
+    }
+
+    private List<Map<String, Object>> fetchList(String endpoint) throws IOException {
+        try (CloseableHttpClient client = HttpClients.custom()
+                .setDefaultRequestConfig(LONG_TIMEOUT)
+                .build()) {
+            HttpGet get = new HttpGet(BACKEND_URL + endpoint);
+            return client.execute(get, resp -> {
+                String body = EntityUtils.toString(resp.getEntity());
+                return MAPPER.readValue(body, new TypeReference<List<Map<String, Object>>>() {});
+            });
+        }
+    }
+}

--- a/oracle-db/frontend/src/main/webapp/WEB-INF/web.xml
+++ b/oracle-db/frontend/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
+  <display-name>ReliPeople HR Portal</display-name>
+</web-app>

--- a/oracle-db/frontend/src/main/webapp/jsp/dashboard.jsp
+++ b/oracle-db/frontend/src/main/webapp/jsp/dashboard.jsp
@@ -1,0 +1,35 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ include file="header.jspf" %>
+
+<h1>HR Dashboard</h1>
+<p style="color:#666; margin-top:-8px;">Self-service portal overview</p>
+
+<div class="stat-grid">
+    <div class="stat-card">
+        <div class="stat-label">Total Employees</div>
+        <div class="stat-value">
+            <c:out value="${stats.totalEmployees != null ? stats.totalEmployees : '—'}"/>
+        </div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-label">Total Departments</div>
+        <div class="stat-value">
+            <c:out value="${stats.totalDepts != null ? stats.totalDepts : '—'}"/>
+        </div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-label">Recent Hires (90d)</div>
+        <div class="stat-value">
+            <c:out value="${stats.recentHires != null ? stats.recentHires : '—'}"/>
+        </div>
+    </div>
+    <div class="stat-card">
+        <div class="stat-label">Pending Leaves</div>
+        <div class="stat-value">
+            <c:out value="${stats.pendingLeaves != null ? stats.pendingLeaves : '—'}"/>
+        </div>
+    </div>
+</div>
+
+<%@ include file="footer.jspf" %>

--- a/oracle-db/frontend/src/main/webapp/jsp/dept-analytics.jsp
+++ b/oracle-db/frontend/src/main/webapp/jsp/dept-analytics.jsp
@@ -1,0 +1,56 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ include file="header.jspf" %>
+
+<h1>Department Analytics</h1>
+<p style="color:#666; margin-top:-8px;">Headcount, compensation, and total payroll by department (with company-wide rollup).</p>
+
+<c:choose>
+    <c:when test="${empty deptData}">
+        <div class="card empty-state"><p>No department data available.</p></div>
+    </c:when>
+    <c:otherwise>
+        <table>
+            <thead>
+                <tr>
+                    <th>Department</th>
+                    <th>City</th>
+                    <th>State</th>
+                    <th class="num">Headcount</th>
+                    <th class="num">Avg Salary</th>
+                    <th class="num">Total Payroll</th>
+                </tr>
+            </thead>
+            <tbody>
+                <c:forEach var="row" items="${deptData}">
+                    <c:set var="isRollup" value="${row.deptName == 'ALL DEPARTMENTS'}"/>
+                    <tr<c:if test="${isRollup}"> class="rollup-row"</c:if>>
+                        <td><c:out value="${row.deptName}"/></td>
+                        <td><c:out value="${empty row.city ? '—' : row.city}"/></td>
+                        <td><c:out value="${empty row.state ? '—' : row.state}"/></td>
+                        <td class="num"><c:out value="${row.headcount}"/></td>
+                        <td class="num">
+                            <c:choose>
+                                <c:when test="${empty row.avgCurrentSalary}">—</c:when>
+                                <c:otherwise>
+                                    <fmt:formatNumber value="${row.avgCurrentSalary}" type="currency" currencySymbol="$" maxFractionDigits="0"/>
+                                </c:otherwise>
+                            </c:choose>
+                        </td>
+                        <td class="num">
+                            <c:choose>
+                                <c:when test="${empty row.totalPayroll}">—</c:when>
+                                <c:otherwise>
+                                    <fmt:formatNumber value="${row.totalPayroll}" type="currency" currencySymbol="$" maxFractionDigits="0"/>
+                                </c:otherwise>
+                            </c:choose>
+                        </td>
+                    </tr>
+                </c:forEach>
+            </tbody>
+        </table>
+    </c:otherwise>
+</c:choose>
+
+<%@ include file="footer.jspf" %>

--- a/oracle-db/frontend/src/main/webapp/jsp/employee-profile.jsp
+++ b/oracle-db/frontend/src/main/webapp/jsp/employee-profile.jsp
@@ -1,0 +1,78 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ include file="header.jspf" %>
+
+<p><a href="/employees" style="color:#1a3a5c; text-decoration:none;">&larr; Back to Employees</a></p>
+
+<c:choose>
+    <c:when test="${empty employee or empty employee.empId}">
+        <div class="card empty-state">
+            <p>Employee not found.</p>
+        </div>
+    </c:when>
+    <c:otherwise>
+        <div class="card">
+            <h1 style="margin-bottom:4px;">
+                <c:out value="${employee.firstName}"/> <c:out value="${employee.lastName}"/>
+            </h1>
+            <p style="color:#666; margin-top:0; font-size:15px;">
+                <c:out value="${employee.jobTitle}"/> &middot; <c:out value="${employee.deptName}"/>
+            </p>
+            <div style="display:grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap:18px; margin-top:20px;">
+                <div>
+                    <div class="stat-label">Employee ID</div>
+                    <div style="font-size:16px; margin-top:4px;"><c:out value="${employee.empId}"/></div>
+                </div>
+                <div>
+                    <div class="stat-label">Email</div>
+                    <div style="font-size:16px; margin-top:4px;"><c:out value="${employee.email}"/></div>
+                </div>
+                <div>
+                    <div class="stat-label">Hire Date</div>
+                    <div style="font-size:16px; margin-top:4px;"><c:out value="${employee.hireDate}"/></div>
+                </div>
+                <div>
+                    <div class="stat-label">Current Salary</div>
+                    <div style="font-size:16px; margin-top:4px;">
+                        <c:choose>
+                            <c:when test="${empty employee.currentSalary}">—</c:when>
+                            <c:otherwise>
+                                <fmt:formatNumber value="${employee.currentSalary}" type="currency" currencySymbol="$" maxFractionDigits="0"/>
+                            </c:otherwise>
+                        </c:choose>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <h2>Salary History</h2>
+        <c:choose>
+            <c:when test="${empty salaryHistory}">
+                <div class="card empty-state"><p>No salary history available.</p></div>
+            </c:when>
+            <c:otherwise>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Effective Date</th>
+                            <th class="num">Salary</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <c:forEach var="sal" items="${salaryHistory}">
+                            <tr>
+                                <td><c:out value="${sal.effectiveDate}"/></td>
+                                <td class="num">
+                                    <fmt:formatNumber value="${sal.salary}" type="currency" currencySymbol="$" maxFractionDigits="0"/>
+                                </td>
+                            </tr>
+                        </c:forEach>
+                    </tbody>
+                </table>
+            </c:otherwise>
+        </c:choose>
+    </c:otherwise>
+</c:choose>
+
+<%@ include file="footer.jspf" %>

--- a/oracle-db/frontend/src/main/webapp/jsp/employees.jsp
+++ b/oracle-db/frontend/src/main/webapp/jsp/employees.jsp
@@ -1,0 +1,55 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ include file="header.jspf" %>
+
+<h1>Employee Directory</h1>
+
+<form method="get" action="/employees" class="search-row">
+    <input type="text" id="search-input" name="search"
+           data-testid="employee-search"
+           placeholder="Search by name or email..."
+           value="<c:out value='${search}'/>" />
+    <button type="submit" id="search-btn">Search</button>
+</form>
+
+<c:choose>
+    <c:when test="${empty employees}">
+        <div class="card empty-state">
+            <p>No employees found<c:if test="${not empty search}"> for "<c:out value='${search}'/>"</c:if>.</p>
+        </div>
+    </c:when>
+    <c:otherwise>
+        <table>
+            <thead>
+                <tr>
+                    <th>Employee ID</th>
+                    <th>Name</th>
+                    <th>Department</th>
+                    <th>Job Title</th>
+                    <th>Email</th>
+                    <th>Hire Date</th>
+                </tr>
+            </thead>
+            <tbody>
+                <c:forEach var="emp" items="${employees}">
+                    <tr data-testid="employee-row">
+                        <td><c:out value="${emp.empId}"/></td>
+                        <td>
+                            <a class="emp-link" data-testid="employee-link"
+                               href="/employees/<c:out value='${emp.empId}'/>">
+                                <c:out value="${emp.fullName}"/>
+                            </a>
+                        </td>
+                        <td><c:out value="${emp.deptName}"/></td>
+                        <td><c:out value="${emp.jobTitle}"/></td>
+                        <td><c:out value="${emp.email}"/></td>
+                        <td><c:out value="${emp.hireDate}"/></td>
+                    </tr>
+                </c:forEach>
+            </tbody>
+        </table>
+    </c:otherwise>
+</c:choose>
+
+<%@ include file="footer.jspf" %>

--- a/oracle-db/frontend/src/main/webapp/jsp/footer.jspf
+++ b/oracle-db/frontend/src/main/webapp/jsp/footer.jspf
@@ -1,0 +1,3 @@
+</main>
+</body>
+</html>

--- a/oracle-db/frontend/src/main/webapp/jsp/header.jspf
+++ b/oracle-db/frontend/src/main/webapp/jsp/header.jspf
@@ -1,0 +1,176 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>ReliPeople HR Portal</title>
+    <style>
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+            background: #f4f4f4;
+            color: #222;
+        }
+        header.topnav {
+            background: #1a3a5c;
+            color: white;
+            padding: 14px 28px;
+            display: flex;
+            align-items: center;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.15);
+        }
+        header.topnav .logo {
+            font-size: 22px;
+            font-weight: bold;
+            margin-right: 40px;
+            letter-spacing: 0.5px;
+        }
+        header.topnav nav a {
+            color: white;
+            text-decoration: none;
+            margin-right: 22px;
+            font-size: 14px;
+            opacity: 0.85;
+            transition: opacity 0.15s;
+        }
+        header.topnav nav a:hover { opacity: 1; }
+        main {
+            max-width: 1300px;
+            margin: 28px auto;
+            padding: 0 24px;
+        }
+        h1 { color: #1a3a5c; margin-top: 0; }
+        h2 { color: #1a3a5c; }
+        .card {
+            background: white;
+            border-radius: 6px;
+            padding: 22px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+            margin-bottom: 20px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            background: white;
+            border-radius: 6px;
+            overflow: hidden;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+        }
+        table th {
+            background: #e9eef4;
+            color: #1a3a5c;
+            text-align: left;
+            padding: 12px 14px;
+            font-size: 13px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+        table td {
+            padding: 11px 14px;
+            border-top: 1px solid #eee;
+            font-size: 14px;
+        }
+        table tr:hover td { background: #fafbfc; }
+        .badge {
+            display: inline-block;
+            padding: 4px 10px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.4px;
+        }
+        .badge-approved { background: #d6f5dc; color: #1f7a3a; }
+        .badge-pending  { background: #fff4cc; color: #8a6a00; }
+        .badge-rejected { background: #fde0e0; color: #a61f1f; }
+        .badge-warn     { background: #ffe8cc; color: #8a4500; }
+        .stat-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 18px;
+        }
+        .stat-card {
+            background: white;
+            border-radius: 6px;
+            padding: 22px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+            border-left: 4px solid #1a3a5c;
+        }
+        .stat-label { color: #666; font-size: 13px; text-transform: uppercase; letter-spacing: 0.5px; }
+        .stat-value { font-size: 36px; font-weight: 700; color: #1a3a5c; margin-top: 6px; }
+        .search-row {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 20px;
+        }
+        .search-row input[type=text] {
+            flex: 1;
+            padding: 10px 12px;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            font-size: 14px;
+        }
+        .search-row button {
+            padding: 10px 22px;
+            background: #1a3a5c;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 14px;
+            font-weight: 600;
+        }
+        .search-row button:hover { background: #234b76; }
+        .emp-link { color: #1a3a5c; text-decoration: none; font-weight: 600; }
+        .emp-link:hover { text-decoration: underline; }
+        .error-msg {
+            background: #fde0e0;
+            color: #a61f1f;
+            padding: 12px 16px;
+            border-radius: 4px;
+            margin-bottom: 18px;
+        }
+        .empty-state {
+            text-align: center;
+            padding: 40px;
+            color: #888;
+        }
+        .rollup-row td {
+            background: #f0f4f8 !important;
+            font-weight: bold;
+        }
+        .page-badge {
+            display: inline-block;
+            padding: 6px 12px;
+            border-radius: 4px;
+            background: #ffe8cc;
+            color: #8a4500;
+            font-size: 12px;
+            font-weight: 600;
+            margin-left: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.4px;
+        }
+        .num { text-align: right; font-variant-numeric: tabular-nums; }
+    </style>
+</head>
+<body>
+<header class="topnav">
+    <div class="logo">ReliPeople</div>
+    <nav>
+        <a href="/" data-testid="nav-dashboard">Dashboard</a>
+        <a href="/employees" data-testid="nav-employees">Employees</a>
+        <a href="/reports/payroll" data-testid="report-payroll">Payroll</a>
+        <a href="/reports/departments" data-testid="report-departments">Departments</a>
+        <a href="/reports/performance" data-testid="report-performance">Performance</a>
+        <a href="/reports/leave-backlog" data-testid="report-leave-backlog">Leave Backlog</a>
+        <a href="/reports/salary-progression" data-testid="report-salary-progression">Salary Progression</a>
+        <a href="/leaves" data-testid="nav-leaves">Leaves</a>
+    </nav>
+</header>
+<main>
+<c:if test="${not empty error}">
+    <div class="error-msg">${error}</div>
+</c:if>

--- a/oracle-db/frontend/src/main/webapp/jsp/leave-backlog-report.jsp
+++ b/oracle-db/frontend/src/main/webapp/jsp/leave-backlog-report.jsp
@@ -1,0 +1,48 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ include file="header.jspf" %>
+
+<h1>Leave Backlog Report
+    <span class="page-badge">Heavy Query — Correlated Subquery</span>
+</h1>
+<p style="color:#666; margin-top:-8px;">Department leave summary with confirmed pending count via correlated subquery.</p>
+
+<c:choose>
+    <c:when test="${empty leaveBacklogData}">
+        <div class="card empty-state"><p>No leave backlog data available.</p></div>
+    </c:when>
+    <c:otherwise>
+        <table>
+            <thead>
+                <tr>
+                    <th>Department</th>
+                    <th class="num">Total Employees</th>
+                    <th class="num">Total Leaves</th>
+                    <th class="num">Pending</th>
+                    <th class="num">Avg Days</th>
+                    <th class="num">Confirmed Pending</th>
+                </tr>
+            </thead>
+            <tbody>
+                <c:forEach var="row" items="${leaveBacklogData}">
+                    <tr>
+                        <td><c:out value="${row.deptName}"/></td>
+                        <td class="num"><c:out value="${row.totalEmployees}"/></td>
+                        <td class="num"><c:out value="${row.totalLeaves}"/></td>
+                        <td class="num"><c:out value="${row.pendingCount}"/></td>
+                        <td class="num">
+                            <c:choose>
+                                <c:when test="${empty row.avgLeaveDays}">—</c:when>
+                                <c:otherwise><fmt:formatNumber value="${row.avgLeaveDays}" maxFractionDigits="1"/></c:otherwise>
+                            </c:choose>
+                        </td>
+                        <td class="num"><c:out value="${row.confirmedPending}"/></td>
+                    </tr>
+                </c:forEach>
+            </tbody>
+        </table>
+    </c:otherwise>
+</c:choose>
+
+<%@ include file="footer.jspf" %>

--- a/oracle-db/frontend/src/main/webapp/jsp/leaves.jsp
+++ b/oracle-db/frontend/src/main/webapp/jsp/leaves.jsp
@@ -1,0 +1,66 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ include file="header.jspf" %>
+
+<h1>Leave Requests</h1>
+<p style="color:#666; margin-top:-8px;">All employee leave requests across the organization.</p>
+
+<div class="search-row" style="gap:8px;">
+    <a href="/leaves" class="badge"
+       style="background:#e9eef4; color:#1a3a5c; text-decoration:none;"
+       data-testid="filter-all">All</a>
+    <a href="/leaves?status=PENDING" class="badge badge-pending"
+       style="text-decoration:none;"
+       data-testid="filter-pending">Pending</a>
+    <a href="/leaves?status=APPROVED" class="badge badge-approved"
+       style="text-decoration:none;"
+       data-testid="filter-approved">Approved</a>
+    <a href="/leaves?status=DENIED" class="badge badge-rejected"
+       style="text-decoration:none;"
+       data-testid="filter-denied">Denied</a>
+</div>
+
+<c:choose>
+    <c:when test="${empty leaves}">
+        <div class="card empty-state"><p>No leave requests found.</p></div>
+    </c:when>
+    <c:otherwise>
+        <table>
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Employee</th>
+                    <th>Department</th>
+                    <th>Start</th>
+                    <th>End</th>
+                    <th class="num">Duration (days)</th>
+                    <th>Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                <c:forEach var="lv" items="${leaves}">
+                    <c:set var="statusStr" value="${lv.status}"/>
+                    <c:set var="badgeClass" value="badge-pending"/>
+                    <c:if test="${statusStr == 'APPROVED'}"><c:set var="badgeClass" value="badge-approved"/></c:if>
+                    <c:if test="${statusStr == 'DENIED'}"><c:set var="badgeClass" value="badge-rejected"/></c:if>
+                    <tr>
+                        <td><c:out value="${lv.requestId}"/></td>
+                        <td><c:out value="${lv.empName}"/></td>
+                        <td><c:out value="${lv.deptName}"/></td>
+                        <td><c:out value="${lv.startDate}"/></td>
+                        <td><c:out value="${lv.endDate}"/></td>
+                        <td class="num"><c:out value="${lv.durationDays}"/></td>
+                        <td>
+                            <span class="badge ${badgeClass}">
+                                <c:out value="${statusStr}"/>
+                            </span>
+                        </td>
+                    </tr>
+                </c:forEach>
+            </tbody>
+        </table>
+    </c:otherwise>
+</c:choose>
+
+<%@ include file="footer.jspf" %>

--- a/oracle-db/frontend/src/main/webapp/jsp/payroll-report.jsp
+++ b/oracle-db/frontend/src/main/webapp/jsp/payroll-report.jsp
@@ -1,0 +1,68 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ include file="header.jspf" %>
+
+<h1>Payroll Report
+    <span class="page-badge">Heavy Query — May Take 10–30s</span>
+</h1>
+<p style="color:#666; margin-top:-8px;">Detailed payroll view with department benchmarks and previous salary comparison.</p>
+
+<c:choose>
+    <c:when test="${empty payrollData}">
+        <div class="card empty-state"><p>No payroll data available.</p></div>
+    </c:when>
+    <c:otherwise>
+        <table>
+            <thead>
+                <tr>
+                    <th>Employee ID</th>
+                    <th>Name</th>
+                    <th>Department</th>
+                    <th>Job Title</th>
+                    <th class="num">Current Salary</th>
+                    <th class="num">Dept Avg</th>
+                    <th class="num">Dept Headcount</th>
+                    <th class="num">Previous Salary</th>
+                </tr>
+            </thead>
+            <tbody>
+                <c:forEach var="row" items="${payrollData}">
+                    <tr>
+                        <td><c:out value="${row.empId}"/></td>
+                        <td><c:out value="${row.fullName}"/></td>
+                        <td><c:out value="${row.deptName}"/></td>
+                        <td><c:out value="${row.jobTitle}"/></td>
+                        <td class="num">
+                            <c:choose>
+                                <c:when test="${empty row.currentSalary}">—</c:when>
+                                <c:otherwise>
+                                    <fmt:formatNumber value="${row.currentSalary}" type="currency" currencySymbol="$" maxFractionDigits="0"/>
+                                </c:otherwise>
+                            </c:choose>
+                        </td>
+                        <td class="num">
+                            <c:choose>
+                                <c:when test="${empty row.deptAvgSalary}">—</c:when>
+                                <c:otherwise>
+                                    <fmt:formatNumber value="${row.deptAvgSalary}" type="currency" currencySymbol="$" maxFractionDigits="0"/>
+                                </c:otherwise>
+                            </c:choose>
+                        </td>
+                        <td class="num"><c:out value="${row.deptHeadcount}"/></td>
+                        <td class="num">
+                            <c:choose>
+                                <c:when test="${empty row.previousSalary}">—</c:when>
+                                <c:otherwise>
+                                    <fmt:formatNumber value="${row.previousSalary}" type="currency" currencySymbol="$" maxFractionDigits="0"/>
+                                </c:otherwise>
+                            </c:choose>
+                        </td>
+                    </tr>
+                </c:forEach>
+            </tbody>
+        </table>
+    </c:otherwise>
+</c:choose>
+
+<%@ include file="footer.jspf" %>

--- a/oracle-db/frontend/src/main/webapp/jsp/performance-report.jsp
+++ b/oracle-db/frontend/src/main/webapp/jsp/performance-report.jsp
@@ -1,0 +1,56 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ include file="header.jspf" %>
+
+<h1>Performance Trends</h1>
+<p style="color:#666; margin-top:-8px;">Review score aggregates by year, department, and role (with rollups).</p>
+
+<c:choose>
+    <c:when test="${empty performanceData}">
+        <div class="card empty-state"><p>No performance data available.</p></div>
+    </c:when>
+    <c:otherwise>
+        <table>
+            <thead>
+                <tr>
+                    <th>Year</th>
+                    <th>Department</th>
+                    <th>Role</th>
+                    <th class="num">Reviews</th>
+                    <th class="num">Avg Score</th>
+                    <th class="num">Min</th>
+                    <th class="num">Max</th>
+                    <th class="num">High Performers</th>
+                </tr>
+            </thead>
+            <tbody>
+                <c:forEach var="row" items="${performanceData}">
+                    <c:set var="yearLabel" value="${empty row.reviewYear ? 'ALL YEARS' : row.reviewYear}"/>
+                    <c:set var="deptLabel" value="${empty row.deptName ? 'ALL DEPTS' : row.deptName}"/>
+                    <c:set var="jobLabel"  value="${empty row.jobTitle ? 'ALL ROLES' : row.jobTitle}"/>
+                    <c:set var="isRollup"  value="${empty row.reviewYear or empty row.deptName or empty row.jobTitle}"/>
+                    <tr<c:if test="${isRollup}"> class="rollup-row"</c:if>>
+                        <td><c:out value="${yearLabel}"/></td>
+                        <td><c:out value="${deptLabel}"/></td>
+                        <td><c:out value="${jobLabel}"/></td>
+                        <td class="num"><c:out value="${row.reviewCount}"/></td>
+                        <td class="num">
+                            <c:choose>
+                                <c:when test="${empty row.avgScore}">—</c:when>
+                                <c:otherwise>
+                                    <fmt:formatNumber value="${row.avgScore}" maxFractionDigits="2" minFractionDigits="2"/>
+                                </c:otherwise>
+                            </c:choose>
+                        </td>
+                        <td class="num"><c:out value="${empty row.minScore ? '—' : row.minScore}"/></td>
+                        <td class="num"><c:out value="${empty row.maxScore ? '—' : row.maxScore}"/></td>
+                        <td class="num"><c:out value="${row.highPerformers}"/></td>
+                    </tr>
+                </c:forEach>
+            </tbody>
+        </table>
+    </c:otherwise>
+</c:choose>
+
+<%@ include file="footer.jspf" %>

--- a/oracle-db/frontend/src/main/webapp/jsp/salary-progression-report.jsp
+++ b/oracle-db/frontend/src/main/webapp/jsp/salary-progression-report.jsp
@@ -1,0 +1,58 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+<%@ include file="header.jspf" %>
+
+<h1>Salary Progression Report
+    <span class="page-badge">Heavy Query — Full Table Scan</span>
+</h1>
+<p style="color:#666; margin-top:-8px;">Top 500 employees by salary growth — requires full scan of all 200K salary records.</p>
+
+<c:choose>
+    <c:when test="${empty salaryProgressionData}">
+        <div class="card empty-state"><p>No salary progression data available.</p></div>
+    </c:when>
+    <c:otherwise>
+        <table>
+            <thead>
+                <tr>
+                    <th>Employee</th>
+                    <th>Department</th>
+                    <th>Job Title</th>
+                    <th class="num">Salary Changes</th>
+                    <th class="num">Starting Salary</th>
+                    <th class="num">Current Salary</th>
+                    <th class="num">Total Growth</th>
+                    <th class="num">Growth %</th>
+                </tr>
+            </thead>
+            <tbody>
+                <c:forEach var="row" items="${salaryProgressionData}">
+                    <tr>
+                        <td><c:out value="${row.employeeName}"/></td>
+                        <td><c:out value="${row.deptName}"/></td>
+                        <td><c:out value="${row.jobTitle}"/></td>
+                        <td class="num"><c:out value="${row.salaryChanges}"/></td>
+                        <td class="num">
+                            <fmt:formatNumber value="${row.startingSalary}" type="currency" currencySymbol="$" maxFractionDigits="0"/>
+                        </td>
+                        <td class="num">
+                            <fmt:formatNumber value="${row.currentSalary}" type="currency" currencySymbol="$" maxFractionDigits="0"/>
+                        </td>
+                        <td class="num">
+                            <fmt:formatNumber value="${row.totalGrowth}" type="currency" currencySymbol="$" maxFractionDigits="0"/>
+                        </td>
+                        <td class="num">
+                            <c:choose>
+                                <c:when test="${empty row.growthPct}">—</c:when>
+                                <c:otherwise><fmt:formatNumber value="${row.growthPct}" maxFractionDigits="1"/>%</c:otherwise>
+                            </c:choose>
+                        </td>
+                    </tr>
+                </c:forEach>
+            </tbody>
+        </table>
+    </c:otherwise>
+</c:choose>
+
+<%@ include file="footer.jspf" %>

--- a/oracle-db/loadgen/Dockerfile
+++ b/oracle-db/loadgen/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install Chromium and ChromeDriver directly from apt (works on amd64 + arm64)
+RUN apt-get update && apt-get install -y \
+    chromium \
+    chromium-driver \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+RUN chmod +x load_gen.py
+
+CMD ["python", "-u", "load_gen.py"]

--- a/oracle-db/loadgen/journeys.py
+++ b/oracle-db/loadgen/journeys.py
@@ -1,0 +1,193 @@
+"""
+ReliPeople user journeys.
+
+Three weighted journeys simulate typical HR-portal traffic:
+
+    browse_employees (50%) - dashboard -> employee directory -> search
+                             -> open 2-3 profiles
+    run_report       (30%) - dashboard -> one of (payroll, departments,
+                             performance), wait for table to render
+    check_leaves     (20%) - navigate to the leave-requests page
+
+Each journey drives the frontend UI via Selenium (no direct backend calls).
+Journeys never raise out of the module - timeouts are logged and the journey
+moves on so the user thread stays alive.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from typing import List, Tuple
+
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    StaleElementReferenceException,
+    TimeoutException,
+    WebDriverException,
+)
+from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
+logger = logging.getLogger(__name__)
+
+# Journey weights (must sum to 100)
+JOURNEY_WEIGHTS: List[Tuple[str, int]] = [
+    ("browse_employees", 50),
+    ("run_report",       30),
+    ("check_leaves",     20),
+]
+
+# Two-letter name fragments - match common first/last name prefixes in the
+# seeded data so searches return meaningful result sets.
+SEARCH_FRAGMENTS = [
+    "Sm", "Jo", "Wi", "Br", "Da", "Ja", "Ma", "Mi", "Ro", "An",
+    "Al", "Ch", "Ga", "He", "Ki", "Le", "Mo", "Pa", "Ri", "Th",
+]
+
+REPORT_PATHS = [
+    "/reports/payroll",
+    "/reports/departments",
+    "/reports/performance",
+    "/reports/leave-backlog",
+    "/reports/salary-progression",
+]
+
+DEFAULT_WAIT_S = 15
+REPORT_WAIT_S = 60  # payroll query can legitimately take 10-30s
+
+
+def pick_journey() -> str:
+    """Pick a journey name using weighted random selection (50/30/20)."""
+    total = sum(w for _, w in JOURNEY_WEIGHTS)
+    r = random.uniform(0, total)
+    cumulative = 0
+    for name, weight in JOURNEY_WEIGHTS:
+        cumulative += weight
+        if r <= cumulative:
+            return name
+    return JOURNEY_WEIGHTS[0][0]
+
+
+def _wait_for_body(driver: WebDriver, timeout: int = DEFAULT_WAIT_S) -> None:
+    try:
+        WebDriverWait(driver, timeout).until(
+            EC.presence_of_element_located((By.TAG_NAME, "body"))
+        )
+    except TimeoutException:
+        logger.warning("Body tag never appeared within %ds", timeout)
+
+
+def journey_browse_employees(driver: WebDriver, frontend_url: str) -> None:
+    """Dashboard -> employee directory -> search -> open 2-3 profiles."""
+    driver.get(frontend_url + "/")
+    _wait_for_body(driver)
+    time.sleep(random.uniform(0.6, 1.2))
+
+    driver.get(frontend_url + "/employees")
+    _wait_for_body(driver)
+
+    term = random.choice(SEARCH_FRAGMENTS)
+    try:
+        search_input = WebDriverWait(driver, DEFAULT_WAIT_S).until(
+            EC.presence_of_element_located((By.ID, "search-input"))
+        )
+        search_input.clear()
+        search_input.send_keys(term)
+        logger.info("browse_employees: searching term=%s", term)
+    except TimeoutException:
+        logger.info("browse_employees: search input not found, skipping search")
+        term = None
+
+    if term is not None:
+        try:
+            btn = WebDriverWait(driver, DEFAULT_WAIT_S).until(
+                EC.element_to_be_clickable((By.ID, "search-btn"))
+            )
+            btn.click()
+        except TimeoutException:
+            logger.info("browse_employees: search button not clickable")
+
+        _wait_for_body(driver)
+        time.sleep(random.uniform(1.0, 2.0))
+
+    # Collect profile links then visit 2-3 of them.
+    profile_hrefs: List[str] = []
+    try:
+        links = driver.find_elements(By.CSS_SELECTOR, "a.emp-link")
+        for link in links:
+            try:
+                href = link.get_attribute("href")
+                if href:
+                    profile_hrefs.append(href)
+            except StaleElementReferenceException:
+                continue
+    except WebDriverException as exc:
+        logger.debug("browse_employees: error collecting links: %s", exc)
+
+    if not profile_hrefs:
+        logger.info("browse_employees: no profile links found on page")
+        return
+
+    sample_n = min(len(profile_hrefs), random.randint(2, 3))
+    for href in random.sample(profile_hrefs, sample_n):
+        try:
+            driver.get(href)
+            _wait_for_body(driver)
+            time.sleep(random.uniform(0.8, 1.6))
+            logger.info("browse_employees: viewed profile=%s", href)
+        except WebDriverException as exc:
+            logger.debug("browse_employees: failed to load profile %s: %s", href, exc)
+
+
+def journey_run_report(driver: WebDriver, frontend_url: str) -> None:
+    """Dashboard briefly -> one random report -> wait for table to render."""
+    driver.get(frontend_url + "/")
+    _wait_for_body(driver)
+    time.sleep(random.uniform(0.5, 1.0))
+
+    path = random.choice(REPORT_PATHS)
+    logger.info("run_report: loading %s", path)
+    driver.get(frontend_url + path)
+
+    try:
+        WebDriverWait(driver, REPORT_WAIT_S).until(
+            EC.presence_of_element_located((By.TAG_NAME, "table"))
+        )
+        logger.info("run_report: table rendered for %s", path)
+    except TimeoutException:
+        logger.warning("run_report: table never rendered for %s within %ds",
+                       path, REPORT_WAIT_S)
+
+    time.sleep(random.uniform(0.8, 1.6))
+
+
+def journey_check_leaves(driver: WebDriver, frontend_url: str) -> None:
+    """Navigate to the leave-requests page and wait for it to render."""
+    driver.get(frontend_url + "/leaves")
+    _wait_for_body(driver)
+
+    try:
+        WebDriverWait(driver, DEFAULT_WAIT_S).until(
+            EC.presence_of_element_located((By.TAG_NAME, "h1"))
+        )
+    except TimeoutException:
+        logger.info("check_leaves: heading never appeared")
+
+    time.sleep(random.uniform(0.8, 1.6))
+    logger.info("check_leaves: completed")
+
+
+JOURNEYS = {
+    "browse_employees": journey_browse_employees,
+    "run_report":       journey_run_report,
+    "check_leaves":     journey_check_leaves,
+}
+
+
+def run_journey(name: str, driver: WebDriver, frontend_url: str) -> None:
+    """Dispatch by journey name - raises KeyError on unknown journey."""
+    JOURNEYS[name](driver, frontend_url)

--- a/oracle-db/loadgen/load_gen.py
+++ b/oracle-db/loadgen/load_gen.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+ReliPeople Selenium Load Generator
+
+Drives continuous traffic against the frontend UI with three weighted journeys:
+
+    browse_employees (50%) - dashboard + employee directory + profile lookup
+    run_report       (30%) - payroll / departments / performance reports
+    check_leaves     (20%) - leave-request listing
+
+One Chromium session per iteration, recycled after each journey (matches the
+busy-beavers pattern - keeps iterations isolated and avoids state drift).
+Defaults: 2 concurrent users, ~8s per iteration.
+"""
+
+import logging
+import os
+import random
+import sys
+import time
+from threading import Thread
+
+import requests
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.chrome.service import Service
+
+from journeys import JOURNEY_WEIGHTS, pick_journey, run_journey
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+logger = logging.getLogger("relipeople.loadgen")
+
+FRONTEND_URL = os.getenv("FRONTEND_URL", "http://frontend:8080")
+USERS = int(os.getenv("LOADGEN_USERS", "2"))
+INTERVAL = float(os.getenv("LOADGEN_INTERVAL", "8"))
+APP_NAME = os.getenv("NEW_RELIC_APP_NAME", "ReliPeople")
+
+
+def create_driver() -> webdriver.Chrome:
+    """Create a headless Chromium driver using the apt-installed binaries."""
+    options = Options()
+    options.binary_location = "/usr/bin/chromium"
+    options.add_argument("--headless")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--disable-gpu")
+    options.add_argument("--window-size=1280,800")
+    options.add_argument("--disable-blink-features=AutomationControlled")
+    options.add_argument(
+        "--user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    )
+    options.add_experimental_option(
+        "prefs",
+        {"profile.default_content_setting_values": {"images": 2}},
+    )
+    service = Service("/usr/bin/chromedriver")
+    driver = webdriver.Chrome(service=service, options=options)
+    # Reports can take 30s+, so give pages a wide page-load budget.
+    driver.set_page_load_timeout(90)
+    return driver
+
+
+def wait_for_frontend() -> bool:
+    """Block until the frontend /health endpoint responds 200."""
+    logger.info("Waiting for frontend at %s ...", FRONTEND_URL)
+    for attempt in range(80):
+        try:
+            resp = requests.get(f"{FRONTEND_URL}/health", timeout=5)
+            if resp.status_code == 200:
+                logger.info("Frontend is ready (attempt %d)", attempt + 1)
+                return True
+        except Exception:
+            pass
+        time.sleep(5)
+    logger.error("Frontend did not become available after 80 attempts")
+    return False
+
+
+def run_user(user_id: int) -> None:
+    """Continuously generate load for one simulated user."""
+    logger.info("User %d starting", user_id)
+
+    while True:
+        driver = None
+        journey = pick_journey()
+        start = time.time()
+        try:
+            driver = create_driver()
+            logger.info("User %d: starting journey=%s", user_id, journey)
+            run_journey(journey, driver, FRONTEND_URL)
+            elapsed = round(time.time() - start, 2)
+            logger.info(
+                "User %d: completed journey=%s elapsed_s=%s",
+                user_id, journey, elapsed,
+            )
+        except Exception as exc:
+            elapsed = round(time.time() - start, 2)
+            logger.error(
+                "User %d: journey=%s failed elapsed_s=%s error=%s",
+                user_id, journey, elapsed, exc,
+            )
+        finally:
+            if driver:
+                try:
+                    driver.quit()
+                except Exception:
+                    pass
+
+        sleep_s = INTERVAL + random.uniform(-1.5, 1.5)
+        time.sleep(max(2, sleep_s))
+
+
+def main() -> None:
+    logger.info("=" * 60)
+    logger.info("%s Load Generator", APP_NAME)
+    logger.info("Frontend : %s", FRONTEND_URL)
+    logger.info("Users    : %d", USERS)
+    logger.info("Interval : %.1fs (+/- 1.5s jitter)", INTERVAL)
+    logger.info("Journeys : %s", JOURNEY_WEIGHTS)
+    logger.info("=" * 60)
+
+    if not wait_for_frontend():
+        sys.exit(1)
+
+    logger.info("Stabilisation pause: 10s")
+    time.sleep(10)
+
+    threads = []
+    for uid in range(1, USERS + 1):
+        t = Thread(target=run_user, args=(uid,), daemon=True)
+        t.start()
+        threads.append(t)
+        logger.info("Started user thread %d", uid)
+        time.sleep(2)  # stagger starts
+
+    logger.info("All %d users active - generating continuous load", USERS)
+    try:
+        while True:
+            time.sleep(60)
+            logger.info("Load generator heartbeat: %d users active", USERS)
+    except KeyboardInterrupt:
+        logger.info("Shutting down load generator")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/oracle-db/loadgen/requirements.txt
+++ b/oracle-db/loadgen/requirements.txt
@@ -1,0 +1,2 @@
+selenium==4.27.1
+requests==2.32.3

--- a/oracle-db/oracle/healthcheck.sh
+++ b/oracle-db/oracle/healthcheck.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Healthcheck: queries LEAVE_REQUESTS (last table seeded) to confirm DB is ready.
+#
+# Two output destinations:
+#   /tmp/hc.log                    — full history, inspect with:
+#                                    docker exec relipeople-oracle cat /tmp/hc.log
+#   stdout                         — last N entries visible via:
+#                                    docker inspect --format='{{range .State.Health.Log}}{{.Output}}{{end}}' relipeople-oracle
+LOG=/tmp/hc.log
+
+RESULT=$(sqlplus -s -L "$APP_USER/$APP_USER_PASSWORD@//localhost:1521/${ORACLE_DATABASE:-FREEPDB1}" 2>&1 <<'SQLEOF'
+SET HEADING OFF
+SET FEEDBACK OFF
+SELECT 1 FROM LEAVE_REQUESTS WHERE ROWNUM=1;
+SQLEOF
+)
+RC=$?
+
+TIMESTAMP=$(date '+%Y-%m-%dT%H:%M:%S')
+RESULT_ONELINE=$(printf '%s' "$RESULT" | tr -s '[:space:]' ' ' | sed 's/^ //;s/ $//')
+
+if printf '%s' "$RESULT" | grep -qE '^[[:space:]]*1'; then
+    STATUS="PASS"
+    EXIT=0
+else
+    STATUS="FAIL"
+    EXIT=1
+fi
+
+LOG_LINE="${TIMESTAMP}  ${STATUS}  sqlplus_rc=${RC}  result=[${RESULT_ONELINE}]"
+printf '%s\n' "$LOG_LINE" >> "$LOG"
+printf '%s\n' "$LOG_LINE"   # captured by docker inspect .State.Health.Log
+
+exit $EXIT

--- a/oracle-db/oracle/init/01-schema.sh
+++ b/oracle-db/oracle/init/01-schema.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# ReliPeople HR Self-Service Portal - Schema
+# Sourced by gvenzl container-entrypoint, so $APP_USER and $APP_USER_PASSWORD are available.
+# Connects as APP_USER in FREEPDB1 so tables land in the app user's schema, not SYS@CDB$ROOT.
+# Note: Foreign-key columns are intentionally left unindexed to force full table scans (better telemetry).
+sqlplus -s "${APP_USER}/${APP_USER_PASSWORD}@//localhost:1521/${ORACLE_DATABASE:-FREEPDB1}" << 'SQLEOF'
+
+CREATE TABLE LOCATIONS (
+    location_id NUMBER(6) GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    city        VARCHAR2(50) NOT NULL,
+    state       VARCHAR2(50),
+    country_id  CHAR(2) NOT NULL
+);
+
+CREATE TABLE JOB_GRADES (
+    job_id     VARCHAR2(10) PRIMARY KEY,
+    job_title  VARCHAR2(100) NOT NULL,
+    min_salary NUMBER(10,2) NOT NULL,
+    max_salary NUMBER(10,2) NOT NULL
+);
+
+CREATE TABLE DEPARTMENTS (
+    dept_id     NUMBER(6) GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    dept_name   VARCHAR2(100) NOT NULL,
+    manager_id  NUMBER(8),
+    location_id NUMBER(6) REFERENCES LOCATIONS (location_id)
+);
+
+CREATE TABLE EMPLOYEES (
+    emp_id     NUMBER(8) GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    first_name VARCHAR2(50) NOT NULL,
+    last_name  VARCHAR2(50) NOT NULL,
+    email      VARCHAR2(100) NOT NULL,
+    dept_id    NUMBER(6) REFERENCES DEPARTMENTS (dept_id),
+    job_id     VARCHAR2(10) REFERENCES JOB_GRADES (job_id),
+    hire_date  DATE NOT NULL
+);
+
+CREATE TABLE SALARY_HISTORY (
+    salary_id      NUMBER(10) GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    emp_id         NUMBER(8) REFERENCES EMPLOYEES (emp_id),
+    salary         NUMBER(10,2) NOT NULL,
+    effective_date DATE NOT NULL
+);
+
+CREATE TABLE PERFORMANCE_REVIEWS (
+    review_id   NUMBER(10) GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    emp_id      NUMBER(8) REFERENCES EMPLOYEES (emp_id),
+    review_year NUMBER(4) NOT NULL,
+    score       NUMBER(2,1) NOT NULL,
+    comments    VARCHAR2(500)
+);
+
+CREATE TABLE LEAVE_REQUESTS (
+    request_id NUMBER(10) GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    emp_id     NUMBER(8) REFERENCES EMPLOYEES (emp_id),
+    dept_id    NUMBER(6) REFERENCES DEPARTMENTS (dept_id),
+    start_date DATE NOT NULL,
+    end_date   DATE NOT NULL,
+    status     VARCHAR2(20) DEFAULT 'PENDING'
+);
+
+COMMIT;
+EXIT
+SQLEOF

--- a/oracle-db/oracle/init/02-seed.sh
+++ b/oracle-db/oracle/init/02-seed.sh
@@ -1,0 +1,197 @@
+#!/bin/sh
+# ReliPeople HR Self-Service Portal - Seed Data
+# Sourced by gvenzl container-entrypoint. Connects as APP_USER to seed data in FREEPDB1.
+# Volumes: LOCATIONS(30) JOB_GRADES(20) DEPARTMENTS(50) EMPLOYEES(50K)
+#          SALARY_HISTORY(200K) PERFORMANCE_REVIEWS(150K) LEAVE_REQUESTS(100K)
+sqlplus -s "${APP_USER}/${APP_USER_PASSWORD}@//localhost:1521/${ORACLE_DATABASE:-FREEPDB1}" << 'SQLEOF'
+
+-- ---------------------------------------------------------------------------
+-- LOCATIONS: 30 rows cycling through 10 US cities
+-- ---------------------------------------------------------------------------
+INSERT INTO LOCATIONS (city, state, country_id)
+SELECT
+    CASE MOD(ROWNUM - 1, 10)
+        WHEN 0 THEN 'New York'
+        WHEN 1 THEN 'Los Angeles'
+        WHEN 2 THEN 'Chicago'
+        WHEN 3 THEN 'Houston'
+        WHEN 4 THEN 'Phoenix'
+        WHEN 5 THEN 'Philadelphia'
+        WHEN 6 THEN 'San Antonio'
+        WHEN 7 THEN 'San Diego'
+        WHEN 8 THEN 'Dallas'
+        WHEN 9 THEN 'San Jose'
+    END AS city,
+    CASE MOD(ROWNUM - 1, 10)
+        WHEN 0 THEN 'NY'
+        WHEN 1 THEN 'CA'
+        WHEN 2 THEN 'IL'
+        WHEN 3 THEN 'TX'
+        WHEN 4 THEN 'AZ'
+        WHEN 5 THEN 'PA'
+        WHEN 6 THEN 'TX'
+        WHEN 7 THEN 'CA'
+        WHEN 8 THEN 'TX'
+        WHEN 9 THEN 'CA'
+    END AS state,
+    'US' AS country_id
+FROM DUAL CONNECT BY LEVEL <= 30;
+
+-- ---------------------------------------------------------------------------
+-- JOB_GRADES: 20 rows (explicit INSERTs for clarity)
+-- ---------------------------------------------------------------------------
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('HR_REP',    'HR Representative',           45000,  70000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('HR_MGR',    'HR Manager',                  80000, 120000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('RECRUITER', 'Talent Recruiter',            50000,  85000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('SW_ENG_I',  'Software Engineer I',         70000,  95000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('SW_ENG_II', 'Software Engineer II',        90000, 125000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('SW_ENG_SR', 'Senior Software Engineer',   120000, 170000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('SW_STAFF',  'Staff Software Engineer',    150000, 210000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('SW_MGR',    'Engineering Manager',        140000, 200000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('DATA_ENG',  'Data Engineer',               95000, 140000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('DATA_SCI',  'Data Scientist',             100000, 150000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('PM_I',      'Product Manager I',           85000, 120000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('PM_SR',     'Senior Product Manager',     125000, 175000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('DESIGNER',  'Product Designer',            80000, 125000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('SALES_REP', 'Sales Representative',        55000,  95000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('SALES_MGR', 'Sales Manager',              110000, 160000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('FIN_ANLST', 'Financial Analyst',           70000, 105000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('ACCT',      'Accountant',                  60000,  95000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('MKT_SPEC',  'Marketing Specialist',        55000,  90000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('SUPPORT',   'Customer Support Specialist', 40000,  70000);
+INSERT INTO JOB_GRADES (job_id, job_title, min_salary, max_salary) VALUES ('OPS_ANLST', 'Operations Analyst',          65000, 100000);
+
+-- ---------------------------------------------------------------------------
+-- DEPARTMENTS: 50 rows
+-- ---------------------------------------------------------------------------
+INSERT INTO DEPARTMENTS (dept_name, manager_id, location_id)
+SELECT
+    CASE MOD(ROWNUM - 1, 10)
+        WHEN 0 THEN 'Engineering - Division '    || TO_CHAR(ROWNUM)
+        WHEN 1 THEN 'Sales - Division '          || TO_CHAR(ROWNUM)
+        WHEN 2 THEN 'Marketing - Division '      || TO_CHAR(ROWNUM)
+        WHEN 3 THEN 'Human Resources - Division '|| TO_CHAR(ROWNUM)
+        WHEN 4 THEN 'Finance - Division '        || TO_CHAR(ROWNUM)
+        WHEN 5 THEN 'Operations - Division '     || TO_CHAR(ROWNUM)
+        WHEN 6 THEN 'Customer Support - Division '|| TO_CHAR(ROWNUM)
+        WHEN 7 THEN 'Product - Division '        || TO_CHAR(ROWNUM)
+        WHEN 8 THEN 'Data Science - Division '   || TO_CHAR(ROWNUM)
+        WHEN 9 THEN 'Design - Division '         || TO_CHAR(ROWNUM)
+    END AS dept_name,
+    NULL AS manager_id,
+    MOD(ROWNUM - 1, 30) + 1 AS location_id
+FROM DUAL CONNECT BY LEVEL <= 50;
+
+COMMIT;
+
+-- ---------------------------------------------------------------------------
+-- EMPLOYEES: 50,000 rows
+-- ---------------------------------------------------------------------------
+INSERT INTO EMPLOYEES (first_name, last_name, email, dept_id, job_id, hire_date)
+SELECT
+    CASE MOD(ROWNUM, 20)
+        WHEN 0  THEN 'James'    WHEN 1  THEN 'Mary'     WHEN 2  THEN 'Robert'
+        WHEN 3  THEN 'Patricia' WHEN 4  THEN 'John'     WHEN 5  THEN 'Jennifer'
+        WHEN 6  THEN 'Michael'  WHEN 7  THEN 'Linda'    WHEN 8  THEN 'David'
+        WHEN 9  THEN 'Elizabeth'WHEN 10 THEN 'William'  WHEN 11 THEN 'Barbara'
+        WHEN 12 THEN 'Richard'  WHEN 13 THEN 'Susan'    WHEN 14 THEN 'Joseph'
+        WHEN 15 THEN 'Jessica'  WHEN 16 THEN 'Thomas'   WHEN 17 THEN 'Sarah'
+        WHEN 18 THEN 'Charles'  WHEN 19 THEN 'Karen'
+    END AS first_name,
+    CASE MOD(ROWNUM, 25)
+        WHEN 0  THEN 'Smith'     WHEN 1  THEN 'Johnson'  WHEN 2  THEN 'Williams'
+        WHEN 3  THEN 'Brown'     WHEN 4  THEN 'Jones'    WHEN 5  THEN 'Garcia'
+        WHEN 6  THEN 'Miller'    WHEN 7  THEN 'Davis'    WHEN 8  THEN 'Rodriguez'
+        WHEN 9  THEN 'Martinez'  WHEN 10 THEN 'Hernandez'WHEN 11 THEN 'Lopez'
+        WHEN 12 THEN 'Gonzalez'  WHEN 13 THEN 'Wilson'   WHEN 14 THEN 'Anderson'
+        WHEN 15 THEN 'Thomas'    WHEN 16 THEN 'Taylor'   WHEN 17 THEN 'Moore'
+        WHEN 18 THEN 'Jackson'   WHEN 19 THEN 'Martin'   WHEN 20 THEN 'Lee'
+        WHEN 21 THEN 'Perez'     WHEN 22 THEN 'Thompson' WHEN 23 THEN 'White'
+        WHEN 24 THEN 'Harris'
+    END AS last_name,
+    LOWER(
+        CASE MOD(ROWNUM, 20)
+            WHEN 0  THEN 'james'    WHEN 1  THEN 'mary'     WHEN 2  THEN 'robert'
+            WHEN 3  THEN 'patricia' WHEN 4  THEN 'john'     WHEN 5  THEN 'jennifer'
+            WHEN 6  THEN 'michael'  WHEN 7  THEN 'linda'    WHEN 8  THEN 'david'
+            WHEN 9  THEN 'elizabeth'WHEN 10 THEN 'william'  WHEN 11 THEN 'barbara'
+            WHEN 12 THEN 'richard'  WHEN 13 THEN 'susan'    WHEN 14 THEN 'joseph'
+            WHEN 15 THEN 'jessica'  WHEN 16 THEN 'thomas'   WHEN 17 THEN 'sarah'
+            WHEN 18 THEN 'charles'  WHEN 19 THEN 'karen'
+        END
+        || ROWNUM || '@relipeople.internal'
+    ) AS email,
+    MOD(ROWNUM, 50) + 1 AS dept_id,
+    CASE MOD(ROWNUM, 20)
+        WHEN 0  THEN 'HR_REP'    WHEN 1  THEN 'HR_MGR'    WHEN 2  THEN 'RECRUITER'
+        WHEN 3  THEN 'SW_ENG_I'  WHEN 4  THEN 'SW_ENG_II' WHEN 5  THEN 'SW_ENG_SR'
+        WHEN 6  THEN 'SW_STAFF'  WHEN 7  THEN 'SW_MGR'    WHEN 8  THEN 'DATA_ENG'
+        WHEN 9  THEN 'DATA_SCI'  WHEN 10 THEN 'PM_I'      WHEN 11 THEN 'PM_SR'
+        WHEN 12 THEN 'DESIGNER'  WHEN 13 THEN 'SALES_REP' WHEN 14 THEN 'SALES_MGR'
+        WHEN 15 THEN 'FIN_ANLST' WHEN 16 THEN 'ACCT'      WHEN 17 THEN 'MKT_SPEC'
+        WHEN 18 THEN 'SUPPORT'   WHEN 19 THEN 'OPS_ANLST'
+    END AS job_id,
+    TRUNC(SYSDATE) - MOD(ROWNUM * 7, 5000) AS hire_date
+FROM (SELECT LEVEL rn FROM DUAL CONNECT BY LEVEL <= 50000);
+
+COMMIT;
+
+-- ---------------------------------------------------------------------------
+-- SALARY_HISTORY: 200,000 rows (4 per employee)
+-- ---------------------------------------------------------------------------
+INSERT INTO SALARY_HISTORY (emp_id, salary, effective_date)
+SELECT
+    e.emp_id,
+    ROUND(
+        jg.min_salary
+        + ((jg.max_salary - jg.min_salary) * (s.raise_num - 1) / 4)
+        + MOD(e.emp_id, 500),
+        2
+    ) AS salary,
+    TRUNC(e.hire_date) + (s.raise_num - 1) * 365 AS effective_date
+FROM EMPLOYEES e
+JOIN JOB_GRADES jg ON jg.job_id = e.job_id
+CROSS JOIN (SELECT LEVEL raise_num FROM DUAL CONNECT BY LEVEL <= 4) s;
+
+COMMIT;
+
+-- ---------------------------------------------------------------------------
+-- PERFORMANCE_REVIEWS: 150,000 rows (3 per employee)
+-- ---------------------------------------------------------------------------
+INSERT INTO PERFORMANCE_REVIEWS (emp_id, review_year, score, comments)
+SELECT
+    e.emp_id,
+    2022 + y.yr_offset AS review_year,
+    ROUND(2.5 + MOD(e.emp_id + y.yr_offset, 26) / 10, 1) AS score,
+    CASE MOD(e.emp_id + y.yr_offset, 5)
+        WHEN 0 THEN 'Exceeded expectations; strong contributor this cycle.'
+        WHEN 1 THEN 'Met all goals; consistent performance throughout the year.'
+        WHEN 2 THEN 'Below expectations on two objectives; development plan in place.'
+        WHEN 3 THEN 'Outstanding impact on cross-functional initiatives.'
+        WHEN 4 THEN 'Solid execution; opportunities identified for growth next cycle.'
+    END AS comments
+FROM EMPLOYEES e
+CROSS JOIN (SELECT LEVEL - 1 yr_offset FROM DUAL CONNECT BY LEVEL <= 3) y;
+
+COMMIT;
+
+-- ---------------------------------------------------------------------------
+-- LEAVE_REQUESTS: 100,000 rows (2 per employee)
+-- ---------------------------------------------------------------------------
+INSERT INTO LEAVE_REQUESTS (emp_id, dept_id, start_date, end_date, status)
+SELECT
+    e.emp_id,
+    e.dept_id,
+    TRUNC(SYSDATE) - MOD(e.emp_id * l.lv_num, 365) AS start_date,
+    TRUNC(SYSDATE) - MOD(e.emp_id * l.lv_num, 365) + MOD(e.emp_id, 10) + 1 AS end_date,
+    CASE MOD(e.emp_id + l.lv_num, 3)
+        WHEN 0 THEN 'PENDING'
+        WHEN 1 THEN 'APPROVED'
+        WHEN 2 THEN 'DENIED'
+    END AS status
+FROM EMPLOYEES e
+CROSS JOIN (SELECT LEVEL lv_num FROM DUAL CONNECT BY LEVEL <= 2) l;
+
+COMMIT;
+EXIT
+SQLEOF

--- a/oracle-db/otel/Dockerfile
+++ b/oracle-db/otel/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL -o /tmp/nrdot.deb \
+      https://download.newrelic.com/database-monitoring/nrdot-collector/nrdot-collector-host-linux-arm64-latest.deb \
+    && dpkg -i /tmp/nrdot.deb \
+    && rm /tmp/nrdot.deb
+
+EXPOSE 4317 4318
+
+ENTRYPOINT ["/usr/bin/nrdot-collector-host"]
+CMD ["--config=/etc/nrdot-collector-host/config.yaml", \
+     "--config=/etc/nrdot-collector-host/internal-telemetry.yaml"]

--- a/oracle-db/otel/config.yaml
+++ b/oracle-db/otel/config.yaml
@@ -1,0 +1,122 @@
+extensions:
+  health_check:
+    endpoint: "0.0.0.0:13133"
+
+receivers:
+  # CDB-level metrics (sessions, SGA, resource limits, tablespaces, containers, etc.)
+  oracledb/cdb:
+    endpoint: "oracle:1521"
+    username: "c##nrdot"
+    password: "${env:ORACLE_NRDOT_PASSWORD}"
+    service: "FREE"
+    collection_interval: 30s
+    timeout: 30s
+    enable_tablespace_scraper: true
+    enable_core_scraper: true
+    enable_system_scraper: true
+    enable_connection_scraper: true
+    enable_container_scraper: true
+    enable_database_info_scraper: true
+
+  # PDB-level metrics + query monitoring (threshold 1ms = capture all queries)
+  oracledb/pdb:
+    endpoint: "oracle:1521"
+    username: "c##nrdot"
+    password: "${env:ORACLE_NRDOT_PASSWORD}"
+    service: "FREEPDB1"
+    collection_interval: 30s
+    timeout: 30s
+    pdb_services: ["ALL"]
+    enable_pdb_scraper: true
+    enable_query_monitoring: true
+    query_monitoring_response_time_threshold: 1
+    query_monitoring_count_threshold: 30
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 256
+
+  batch:
+
+  transform/clear_metadata:
+    metric_statements:
+      - context: metric
+        statements:
+          - set(metric.description, "")
+          - set(metric.unit, "")
+
+  filter/exec_plan_and_query_details_include:
+    metrics:
+      include:
+        match_type: strict
+        metric_names:
+          - oracledb.execution_plan
+          - oracledb.slow_queries.query_details
+
+  filter/exec_plan_and_query_details_exclude:
+    metrics:
+      exclude:
+        match_type: strict
+        metric_names:
+          - oracledb.execution_plan
+          - oracledb.slow_queries.query_details
+
+  # Convert cumulative oracle connection counters to delta for NR ingest
+  cumulativetodelta/oracle:
+    include:
+      match_type: strict
+      metrics:
+        - oracledb.connection.bytes_received
+        - oracledb.connection.bytes_sent
+        - oracledb.connection.execute_count
+        - oracledb.connection.logons_cumulative
+        - oracledb.connection.parse_count_hard
+        - oracledb.connection.parse_count_total
+        - oracledb.connection.sqlnet_roundtrips
+        - oracledb.connection.user_commits
+        - oracledb.connection.user_rollbacks
+
+  resourcedetection/db_safe:
+    detectors: ["system"]
+    override: false
+    system:
+      hostname_sources: ["os"]
+      resource_attributes:
+        host.id:
+          enabled: true
+
+connectors:
+  metricsaslogs:
+    include_resource_attributes: true
+    include_scope_info: true
+
+exporters:
+  otlp:
+    # gRPC exporter requires host:port — no scheme prefix.
+    # EU accounts: otlp.eu01.nr-data.net:443
+    endpoint: "${env:NR_OTLP_ENDPOINT:-otlp.nr-data.net:443}"
+    headers:
+      api-key: "${env:NEW_RELIC_LICENSE_KEY}"
+    compression: gzip
+    tls:
+      insecure: false
+
+service:
+  extensions: [health_check]
+  pipelines:
+    # Oracle DB metrics (standard)
+    metrics/oracledb:
+      receivers: [oracledb/cdb, oracledb/pdb]
+      processors: [memory_limiter, resourcedetection/db_safe, cumulativetodelta/oracle, batch, transform/clear_metadata, filter/exec_plan_and_query_details_exclude]
+      exporters: [otlp]
+
+    # Execution plan + slow query details → NR log events
+    metrics/exec_plan_and_query_details_to_logs:
+      receivers: [oracledb/cdb, oracledb/pdb]
+      processors: [filter/exec_plan_and_query_details_include]
+      exporters: [metricsaslogs]
+    logs/oracledb:
+      receivers: [metricsaslogs]
+      processors: [memory_limiter, resourcedetection/db_safe, batch]
+      exporters: [otlp]

--- a/oracle-db/otel/internal-telemetry.yaml
+++ b/oracle-db/otel/internal-telemetry.yaml
@@ -1,0 +1,65 @@
+##### Example configuration for internal telemetry
+# This configuration is intended to be used in conjunction with a configuration of components and pipelines. The
+# collector supports config merging on startup.
+##### Requirements
+# - nrdot-collector (any distro) >= 1.3.0 or collector core version >= v1.35.0 / v0.129.0
+##### Configuration via environment variables
+# For official documentation, see: https://opentelemetry.io/docs/collector/internal-telemetry/
+## Required
+# - INTERNAL_TELEMETRY_NEW_RELIC_LICENSE_KEY
+## Optional
+# - INTERNAL_TELEMETRY_SERVICE_NAME: defaults to 'otel-collector'; determines entity name in New Relic
+# - INTERNAL_TELEMETRY_OTLP_ENDPOINT: defaults to 'https://otlp.nr-data.net'; see https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/ and https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp-troubleshooting/
+# - INTERNAL_TELEMETRY_METRICS_LEVEL: defaults to 'detailed'; other values are 'normal', 'basic', 'none'
+# - INTERNAL_TELEMETRY_LOG_LEVEL: defaults to INFO; other values are DEBUG, WARN, ERROR
+# - INTERNAL_TELEMETRY_TRACE_LEVEL: defaults to 'none' (traces disabled); other value is 'basic'
+# - INTERNAL_TELEMETRY_TRACE_SAMPLE_RATIO: defaults to 0.01, i.e. 1% sampling; has no effect if TRACE_LEVEL is 'none'
+service:
+  telemetry:
+    metrics:
+      level: "${env:INTERNAL_TELEMETRY_METRICS_LEVEL:-detailed}"
+      readers:
+        - periodic:
+            exporter:
+              otlp:
+                protocol: http/protobuf
+                endpoint: "${env:INTERNAL_TELEMETRY_OTLP_ENDPOINT:-https://otlp.nr-data.net}"
+                headers:
+                  - name: api-key
+                    value: "${env:INTERNAL_TELEMETRY_NEW_RELIC_LICENSE_KEY}"
+    logs:
+      level: "${env:INTERNAL_TELEMETRY_LOG_LEVEL:-INFO}"
+      sampling:
+        enabled: true
+        tick: 10s
+        initial: 10
+        thereafter: 100
+      processors:
+        - batch:
+            exporter:
+              otlp:
+                protocol: http/protobuf
+                endpoint: "${env:INTERNAL_TELEMETRY_OTLP_ENDPOINT:-https://otlp.nr-data.net}"
+                headers:
+                  - name: api-key
+                    value: "${env:INTERNAL_TELEMETRY_NEW_RELIC_LICENSE_KEY}"
+    traces:
+      level: "${env:INTERNAL_TELEMETRY_TRACE_LEVEL:-none}"
+      sampler:
+        parent_based:
+          root:
+            trace_id_ratio_based:
+              ratio: ${env:INTERNAL_TELEMETRY_TRACE_SAMPLE_RATIO:-0.01}
+      processors:
+        - batch:
+            exporter:
+              otlp:
+                protocol: http/protobuf
+                endpoint: "${env:INTERNAL_TELEMETRY_OTLP_ENDPOINT:-https://otlp.nr-data.net}"
+                headers:
+                  - name: api-key
+                    value: "${env:INTERNAL_TELEMETRY_NEW_RELIC_LICENSE_KEY}"
+    resource:
+      newrelic.collector_telemetry.version: 0.4.0
+      newrelic.service.type: otel_collector
+      service.name: "${env:INTERNAL_TELEMETRY_SERVICE_NAME:-otel-collector}"


### PR DESCRIPTION
## Summary

  - Adds a complete self-contained enterprise HR demo app (oracle-db/) designed to showcase New Relic Oracle Database monitoring with realistic, observable workloads from the moment you start it
  - Stack: Tomcat/JSP frontend + Spring Boot 3.2 backend + Oracle Free 23c — seeded with 500k+ rows across 7 tables, NR Java agent on both Java services, NRDOT collector scraping Oracle DB metrics via the Oracle receiver
  - Slow queries by design: all FK joins are unindexed; 7 endpoints produce full table scans, window functions, correlated subqueries, and hash joins to surface Oracle wait events and query plan analysis in New Relic
  - Selenium loadgen drives continuous traffic across all journeys (browse 50% / reports 30% / leaves 20%) with configurable concurrency and pacing
  - Oracle DB entity linking documented as an optional step — uncommenting transaction_tracer.sql_metadata_comments: "nr_service_guid" in newrelic.yml links APM service traces directly to the Oracle DB entity via SQL comments read from V$SQL
  - Follows the .env.example / .env pattern for both environment config and NR agent config (newrelic.yml.example); actual newrelic.yml files are gitignored so local entity-linking changes don't pollute commits